### PR TITLE
feat: Telegram bot menu, message overhaul, debug scripts & Swagger collapse

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"prisma:reset": "npx prisma migrate reset --schema=./prisma/schema.prisma",
 		"migrate:storj": "ts-node prisma/scripts/migrate-storj-to-db.ts",
 		"verify:migration": "ts-node prisma/scripts/verify-migration.ts",
+		"telegram:mocks": "ts-node -r tsconfig-paths/register scripts/send-telegram-mocks.ts",
 		"infra:up": "docker stack deploy -c stack.testing.yml frankencoin-api",
 		"infra:down": "docker stack remove frankencoin-api"
 	},

--- a/scripts/fps-debug.html
+++ b/scripts/fps-debug.html
@@ -1,0 +1,329 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>FPS Price & Earnings Debug</title>
+		<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+		<style>
+			* { box-sizing: border-box; margin: 0; padding: 0; }
+			body { font-family: monospace; background: #f5f5f5; color: #111; padding: 20px; }
+			h1 { font-size: 1.2rem; margin-bottom: 12px; color: #000; }
+			h2 { font-size: 0.95rem; color: #92400e; margin-bottom: 6px; }
+			#controls {
+				display: flex; gap: 12px; align-items: center;
+				margin-bottom: 16px; flex-wrap: wrap;
+			}
+			#base-url {
+				flex: 1; min-width: 360px;
+				background: #fff; border: 1px solid #ccc;
+				color: #111; padding: 6px 10px;
+				border-radius: 4px; font-family: monospace;
+			}
+			button {
+				background: #2563eb; color: #fff; border: none;
+				padding: 7px 16px; border-radius: 4px; cursor: pointer; font-family: monospace;
+			}
+			button:hover { background: #1d4ed8; }
+			#status { font-size: 0.8rem; color: #666; }
+			.section { margin-bottom: 28px; }
+			.stat-row {
+				display: flex; gap: 20px; flex-wrap: wrap;
+				margin-bottom: 14px; font-size: 0.82rem; color: #555;
+			}
+			.stat-row span b { color: #111; }
+			.chart-wrap {
+				position: relative; width: 100%; height: 340px;
+				background: #fff; border-radius: 6px; padding: 16px;
+				border: 1px solid #e0e0e0; margin-bottom: 8px;
+			}
+			.chart-wrap.tall { height: 420px; }
+			.note {
+				font-size: 0.74rem; color: #444; line-height: 1.7;
+				margin-bottom: 10px;
+			}
+			.note b { color: #111; }
+			.note code { color: #1d4ed8; }
+			table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+			th {
+				text-align: left; padding: 6px 10px;
+				background: #f0f0f0; color: #444;
+				border-bottom: 1px solid #ddd;
+			}
+			td { padding: 5px 10px; border-bottom: 1px solid #eee; }
+			td.pos     { color: #16a34a; }
+			td.neg     { color: #dc2626; }
+			td.neutral { color: #475569; }
+		</style>
+	</head>
+	<body>
+		<h1>FPS — Price &amp; Earnings Debug</h1>
+
+		<div id="controls">
+			<input id="base-url" type="text" value="https://api.frankencoin.com" />
+			<button onclick="load()">Load</button>
+			<span id="status"></span>
+		</div>
+
+		<div id="stats" class="stat-row"></div>
+
+		<!-- CHART 1: FPS Price + Implied Earnings Value -->
+		<div class="section">
+			<h2>FPS Price vs Implied Earnings Value (earningsPerFPS × 3)</h2>
+			<div class="chart-wrap tall">
+				<canvas id="chart-price"></canvas>
+			</div>
+		</div>
+
+		<!-- CHART 2: daily Δ earningsPerFPS -->
+		<div class="section">
+			<h2>Daily Δ earningsPerFPS</h2>
+			<p class="note">
+				<b>earningsPerFPS</b> is cumulative on-chain — this chart shows the day-over-day delta.
+				Green = earnings accrued, red = loss day.
+			</p>
+			<div class="chart-wrap">
+				<canvas id="chart-daily-eps"></canvas>
+			</div>
+		</div>
+
+		<!-- CHART 3: realized + annual combined -->
+		<div class="section">
+			<h2>Realized Net Earnings (rolling 365d) &amp; Annual Net Earnings (annualized projection)</h2>
+			<p class="note">
+				<span style="color:#7c3aed">■</span> <b>realizedNetEarnings</b> — rolling 365-day window: <code>(totalInflow − totalOutflow)</code> for the trailing year.
+				Drops occur when a high-earning day rolls out of the window, or when loss events (liquidation shortfalls, bad debt) push outflow above inflow.
+			</p>
+			<p class="note" style="margin-top:6px">
+				<span style="color:#d97706">■</span> <b>annualNetEarnings</b> — forward projection: implied annual earnings from avg borrow rate × total minted,
+				minus projected savings interest cost (saved amount × save rate). Forward-looking, not realized.
+			</p>
+			<div class="chart-wrap">
+				<canvas id="chart-earnings"></canvas>
+			</div>
+		</div>
+
+		<!-- TABLE -->
+		<div class="section">
+			<h2>Per-Day Earnings Table</h2>
+			<div style="overflow-x:auto">
+			<table>
+				<thead>
+					<tr>
+						<th>Date</th>
+						<th>FPS Price</th>
+						<th>Implied EV (×3)</th>
+						<th>Price / IEV</th>
+						<th>earningsPerFPS</th>
+						<th>Δ earningsPerFPS</th>
+						<th>annualNetEarnings</th>
+						<th>realizedNetEarnings</th>
+						<th>FPS Supply</th>
+					</tr>
+				</thead>
+				<tbody id="table-body"></tbody>
+			</table>
+			</div>
+		</div>
+
+		<script>
+		const DECIMALS   = 1e18;
+		const MULTIPLIER = 3;
+		let charts = {};
+
+		function setStatus(msg, color) {
+			const el = document.getElementById('status');
+			el.textContent = msg;
+			el.style.color = color || '#666';
+		}
+
+		function fmt(n, decimals = 4) {
+			if (n == null || isNaN(n)) return '—';
+			return n.toLocaleString('en-US', { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
+		}
+		function fmtShort(n) { return fmt(n, 2); }
+		function fmtBig(n) {
+			if (Math.abs(n) >= 1e9) return (n / 1e9).toFixed(2) + 'B';
+			if (Math.abs(n) >= 1e6) return (n / 1e6).toFixed(2) + 'M';
+			if (Math.abs(n) >= 1e3) return (n / 1e3).toFixed(2) + 'K';
+			return n.toFixed(2);
+		}
+
+		function fromWei(val) {
+			if (val == null) return null;
+			try { return Number(BigInt(val)) / DECIMALS; } catch { return null; }
+		}
+
+		function destroyChart(id) {
+			if (charts[id]) { charts[id].destroy(); delete charts[id]; }
+		}
+
+		function makeChart(id, type, labels, datasets, opts = {}) {
+			destroyChart(id);
+			const ctx = document.getElementById(id).getContext('2d');
+			charts[id] = new Chart(ctx, {
+				type,
+				data: { labels, datasets },
+				options: {
+					responsive: true, maintainAspectRatio: false, animation: false,
+					interaction: { mode: 'index', intersect: false },
+					plugins: {
+						legend: { labels: { color: '#333', boxWidth: 12, font: { size: 11 } } },
+						tooltip: { backgroundColor: '#fff', titleColor: '#666', bodyColor: '#111', borderColor: '#ddd', borderWidth: 1 },
+					},
+					scales: {
+						x: { ticks: { color: '#888', maxTicksLimit: 16, maxRotation: 45 }, grid: { color: '#ececec' } },
+						y: { ticks: { color: '#888' }, grid: { color: '#ececec' }, ...(opts.y || {}) },
+						...(opts.y2 ? { y2: { position: 'right', ticks: { color: '#888' }, grid: { drawOnChartArea: false }, ...opts.y2 } } : {}),
+					},
+					...opts.extra,
+				},
+			});
+		}
+
+		async function load() {
+			const base = document.getElementById('base-url').value.trim().replace(/\/$/, '');
+			const url  = `${base}/analytics/dailyLog/json`;
+			setStatus('Fetching…');
+			let raw;
+			try {
+				const res = await fetch(url);
+				if (!res.ok) throw new Error(`HTTP ${res.status}`);
+				raw = await res.json();
+			} catch (e) {
+				setStatus('Error: ' + e.message, '#dc2626');
+				return;
+			}
+
+			const arr = Array.isArray(raw) ? raw : (raw.logs ?? Object.values(raw).find(v => Array.isArray(v)) ?? []);
+			const entries = arr
+				.filter(e => e.date && e.fpsPrice != null)
+				.sort((a, b) => (a.date < b.date ? -1 : 1));
+
+			if (entries.length === 0) {
+				setStatus('No usable entries found', '#dc2626');
+				return;
+			}
+			setStatus(`Loaded ${entries.length} daily entries`, '#16a34a');
+
+			const labels            = entries.map(e => e.date);
+			const fpsPrice          = entries.map(e => fromWei(e.fpsPrice));
+			const fpsTotalSupply    = entries.map(e => fromWei(e.fpsTotalSupply));
+			const earningsPerFPS    = entries.map(e => fromWei(e.earningsPerFPS));
+			const annualNetEarnings = entries.map(e => fromWei(e.annualNetEarnings));
+			const realizedNet       = entries.map(e => fromWei(e.realizedNetEarnings));
+
+			const dailyEPS = earningsPerFPS.map((v, i) =>
+				i === 0 ? 0 : (v != null && earningsPerFPS[i-1] != null ? v - earningsPerFPS[i-1] : null)
+			);
+
+			const impliedEV    = earningsPerFPS.map(v => v != null ? v * MULTIPLIER : null);
+			const priceOverIEV = fpsPrice.map((p, i) =>
+				(p != null && impliedEV[i] != null && impliedEV[i] !== 0) ? p / impliedEV[i] : null
+			);
+
+			const last = entries.length - 1;
+			const latestPrice  = fpsPrice[last];
+			const latestIEV    = impliedEV[last];
+			const latestEPS    = earningsPerFPS[last];
+			const latestAnnual = annualNetEarnings[last];
+			const latestRealiz = realizedNet[last];
+			const latestRatio  = priceOverIEV[last];
+
+			document.getElementById('stats').innerHTML = `
+				<span>Entries: <b>${entries.length}</b></span>
+				<span>Range: <b>${labels[0]}</b> → <b>${labels[last]}</b></span>
+				<span>FPS Price: <b>${fmtShort(latestPrice)} ZCHF</b></span>
+				<span>Implied EV (×${MULTIPLIER}): <b>${fmtShort(latestIEV)} ZCHF</b></span>
+				<span>Price / IEV: <b style="color:${latestRatio != null && latestRatio < 1 ? '#16a34a' : '#d97706'}">${latestRatio != null ? latestRatio.toFixed(3) : '—'}</b></span>
+				<span>earningsPerFPS: <b>${fmt(latestEPS)} ZCHF</b></span>
+				<span>Annual Net Earnings: <b>${fmtBig(latestAnnual ?? 0)} ZCHF</b></span>
+				<span>Realized Net (365d): <b>${fmtBig(latestRealiz ?? 0)} ZCHF</b></span>
+			`;
+
+			makeChart('chart-price', 'line', labels, [
+				{
+					label: 'FPS Price (ZCHF)',
+					data: fpsPrice,
+					borderColor: '#2563eb',
+					backgroundColor: 'rgba(37,99,235,0.06)',
+					borderWidth: 2, pointRadius: 0, tension: 0.1, fill: false, yAxisID: 'y',
+				},
+				{
+					label: `Implied Earnings Value (earningsPerFPS × ${MULTIPLIER})`,
+					data: impliedEV,
+					borderColor: '#16a34a',
+					backgroundColor: 'rgba(22,163,74,0.05)',
+					borderWidth: 1.5, borderDash: [4, 3], pointRadius: 0, tension: 0.1, fill: false, yAxisID: 'y',
+				},
+				{
+					label: 'Price / IEV ratio',
+					data: priceOverIEV,
+					borderColor: '#d97706',
+					borderWidth: 1, borderDash: [2, 4], pointRadius: 0, tension: 0, fill: false, yAxisID: 'y2',
+				},
+			], {
+				y:  { title: { display: true, text: 'ZCHF', color: '#888' } },
+				y2: { title: { display: true, text: 'Price / IEV', color: '#888' }, beginAtZero: false },
+			});
+
+			makeChart('chart-daily-eps', 'bar', labels, [
+				{
+					label: 'Daily Δ earningsPerFPS (ZCHF)',
+					data: dailyEPS,
+					backgroundColor: dailyEPS.map(v => (v != null && v >= 0) ? 'rgba(22,163,74,0.55)' : 'rgba(220,38,38,0.55)'),
+					borderWidth: 0,
+				},
+			]);
+
+			makeChart('chart-earnings', 'line', labels, [
+				{
+					label: 'Realized Net Earnings (rolling 365d)',
+					data: realizedNet,
+					borderColor: '#7c3aed',
+					backgroundColor: 'rgba(124,58,237,0.06)',
+					borderWidth: 1.5, pointRadius: 0, tension: 0.1, fill: true,
+				},
+				{
+					label: 'Annual Net Earnings (annualized projection)',
+					data: annualNetEarnings,
+					borderColor: '#d97706',
+					backgroundColor: 'rgba(217,119,6,0.04)',
+					borderWidth: 1.5, borderDash: [5, 3], pointRadius: 0, tension: 0.1, fill: false,
+				},
+			]);
+
+			const tbody = document.getElementById('table-body');
+			tbody.innerHTML = entries.map((e, i) => {
+				const p     = fpsPrice[i];
+				const iev   = impliedEV[i];
+				const eps   = earningsPerFPS[i];
+				const deps  = dailyEPS[i];
+				const ann   = annualNetEarnings[i];
+				const real  = realizedNet[i];
+				const sup   = fpsTotalSupply[i];
+				const ratio = priceOverIEV[i];
+
+				const ievClass   = iev != null && p != null ? (iev > p ? 'pos' : 'neg') : 'neutral';
+				const ratioClass = ratio != null ? (ratio < 1 ? 'pos' : ratio > 1.5 ? 'neg' : 'neutral') : 'neutral';
+				const depsClass  = deps != null ? (deps >= 0 ? 'pos' : 'neg') : 'neutral';
+				const annClass   = ann  != null ? (ann  >= 0 ? 'pos' : 'neg') : 'neutral';
+				const realClass  = real != null ? (real >= 0 ? 'pos' : 'neg') : 'neutral';
+
+				return `<tr>
+					<td>${e.date}</td>
+					<td class="neutral">${fmt(p)}</td>
+					<td class="${ievClass}">${fmt(iev)}</td>
+					<td class="${ratioClass}">${ratio != null ? ratio.toFixed(3) : '—'}</td>
+					<td class="neutral">${fmt(eps)}</td>
+					<td class="${depsClass}">${deps != null ? (deps >= 0 ? '+' : '') + fmt(deps) : '—'}</td>
+					<td class="${annClass}">${ann  != null ? fmtBig(ann)  : '—'}</td>
+					<td class="${realClass}">${real != null ? fmtBig(real) : '—'}</td>
+					<td class="neutral">${sup  != null ? fmtBig(sup)  : '—'}</td>
+				</tr>`;
+			}).join('');
+		}
+
+		load();
+		</script>
+	</body>
+</html>

--- a/scripts/savings-debug.html
+++ b/scripts/savings-debug.html
@@ -1,0 +1,507 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>ZCHF Savings Debug</title>
+		<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+		<style>
+			* { box-sizing: border-box; margin: 0; padding: 0; }
+			body { font-family: monospace; background: #f5f5f5; color: #111; padding: 20px; }
+			h1 { font-size: 1.2rem; margin-bottom: 12px; color: #000; }
+			h2 { font-size: 1rem; margin-bottom: 8px; color: #92400e; }
+			h3 { font-size: 0.85rem; margin-bottom: 6px; color: #475569; }
+			#controls {
+				display: flex; gap: 12px; align-items: center;
+				margin-bottom: 16px; flex-wrap: wrap;
+			}
+			#base-url {
+				flex: 1; min-width: 320px;
+				background: #fff; border: 1px solid #ccc;
+				color: #111; padding: 6px 10px;
+				border-radius: 4px; font-family: monospace;
+			}
+			button {
+				background: #2563eb; color: #fff; border: none;
+				padding: 7px 16px; border-radius: 4px; cursor: pointer; font-family: monospace;
+			}
+			button:hover { background: #1d4ed8; }
+			#status { font-size: 0.8rem; color: #666; }
+			#stats {
+				display: flex; gap: 20px; flex-wrap: wrap;
+				margin-bottom: 14px; font-size: 0.82rem; color: #555;
+			}
+			#stats span b { color: #111; }
+			.chart-container {
+				position: relative; width: 100%; height: 400px;
+				background: #fff; border-radius: 6px; padding: 16px;
+				border: 1px solid #e0e0e0; margin-bottom: 20px;
+			}
+			.section { margin-top: 20px; }
+			table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+			th {
+				text-align: left; padding: 6px 10px;
+				background: #f0f0f0; color: #444;
+				border-bottom: 1px solid #ddd;
+			}
+			td { padding: 5px 10px; border-bottom: 1px solid #eee; }
+			tr:hover td { background: #fafafa; }
+			.tag {
+				display: inline-block; padding: 1px 6px;
+				border-radius: 3px; font-size: 0.72rem;
+			}
+			.tag-blue   { background: #dbeafe; color: #1d4ed8; }
+			.tag-green  { background: #dcfce7; color: #15803d; }
+			.tag-yellow { background: #fef9c3; color: #b45309; }
+			.tag-red    { background: #fee2e2; color: #b91c1c; }
+			.tag-gray   { background: #f3f4f6; color: #6b7280; }
+			.chain-block {
+				background: #fff; border: 1px solid #e0e0e0;
+				border-radius: 6px; padding: 12px 16px; margin-bottom: 12px;
+			}
+			.chain-block h3 { margin-bottom: 10px; }
+			.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+			@media (max-width: 700px) { .grid-2 { grid-template-columns: 1fr; } }
+		</style>
+	</head>
+	<body>
+		<h1>ZCHF Savings — Debug</h1>
+
+		<div id="controls">
+			<input id="base-url" type="text" value="https://api.frankencoin.com" />
+			<button onclick="load()">Load</button>
+			<span id="status"></span>
+		</div>
+
+		<div id="stats"></div>
+
+		<div class="section">
+			<h2>Interest Rate History</h2>
+			<div class="chart-container">
+				<canvas id="chart-rates"></canvas>
+			</div>
+		</div>
+
+		<div class="section" id="section-status">
+			<h2>Current Status (per chain / module)</h2>
+			<div id="status-blocks"></div>
+		</div>
+
+		<div class="section" id="section-unsynced">
+			<h2>Unsynced Bridged Savings Modules</h2>
+			<table>
+				<thead>
+					<tr>
+						<th>Chain</th><th>Module</th><th>Current Rate (PPM)</th><th>Current Rate (%)</th>
+						<th>Expected (ETH Savings)</th><th>Δ PPM</th><th>Last Change (UTC)</th><th>Tx Hash</th>
+					</tr>
+				</thead>
+				<tbody id="unsynced-table"></tbody>
+			</table>
+		</div>
+
+		<div class="section" id="section-rates">
+			<h2>Rate Changes (chronological)</h2>
+			<table>
+				<thead>
+					<tr>
+						<th>#</th><th>Date (UTC)</th><th>Chain</th><th>Module</th>
+						<th>Rate (PPM)</th><th>Rate (%)</th><th>Δ Rate</th><th>Tx Hash</th>
+					</tr>
+				</thead>
+				<tbody id="rates-table"></tbody>
+			</table>
+		</div>
+
+		<div class="section" id="section-proposals">
+			<h2>Rate Proposals (chronological)</h2>
+			<table>
+				<thead>
+					<tr>
+						<th>#</th><th>Proposed At (UTC)</th><th>Chain</th><th>Module</th>
+						<th>Proposed Rate</th><th>Proposed Rate (%)</th>
+						<th>Effective At (UTC)</th><th>Proposer</th><th>Tx Hash</th>
+					</tr>
+				</thead>
+				<tbody id="proposals-table"></tbody>
+			</table>
+		</div>
+
+		<div class="section" id="section-ranked">
+			<h2>Top 20 Accounts by Balance</h2>
+			<table>
+				<thead>
+					<tr>
+						<th>Rank</th><th>Account</th><th>Chain</th><th>Balance (ZCHF)</th>
+						<th>Total Saved</th><th>Interest Earned</th><th>Withdrawn</th><th>Last Updated</th>
+					</tr>
+				</thead>
+				<tbody id="ranked-table"></tbody>
+			</table>
+		</div>
+
+		<script>
+		const CHAIN_NAMES  = { 1: 'Ethereum', 100: 'Gnosis', 8453: 'Base', 10: 'Optimism', 137: 'Polygon' };
+		const MODULE_COLORS = { 'Savings': '#2563eb', 'Mint Rate': '#d97706' };
+
+		let chartRates = null;
+
+		function setStatus(msg, color) {
+			const el = document.getElementById('status');
+			el.textContent = msg;
+			el.style.color = color || '#666';
+		}
+
+		function fmt(weiStr, decimals = 18) {
+			const v = Number(BigInt(weiStr) * 10000n / BigInt(10 ** decimals)) / 10000;
+			return v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+		}
+
+		function ppm(rate) { return (rate / 10000).toFixed(2) + '%'; }
+
+		function ts(unix) {
+			return new Date(unix * 1000).toISOString().replace('T', ' ').slice(0, 16);
+		}
+
+		function shortAddr(addr) { return addr ? addr.slice(0, 8) + '…' + addr.slice(-6) : '—'; }
+		function shortHash(hash) { return hash ? hash.slice(0, 10) + '…' : '—'; }
+
+		function chainLabel(chainId) {
+			return CHAIN_NAMES[chainId] ? `${CHAIN_NAMES[chainId]} (${chainId})` : `Chain ${chainId}`;
+		}
+
+		function moduleLabel(chainId, module) {
+			if (Number(chainId) === 1) {
+				const prefix = module.toLowerCase().slice(0, 4);
+				if (prefix === '0x27') return 'Savings';
+				if (prefix === '0x3b') return 'Mint Rate';
+			}
+			return 'Synced';
+		}
+
+		function seriesLabel(chainId, module) {
+			return `${chainLabel(Number(chainId))} · ${moduleLabel(chainId, module)}`;
+		}
+
+		function moduleColor(chainId, module) {
+			return MODULE_COLORS[moduleLabel(chainId, module)] || '#64748b';
+		}
+
+		async function fetchJson(url) {
+			const res = await fetch(url);
+			if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+			return res.json();
+		}
+
+		async function load() {
+			const base = document.getElementById('base-url').value.trim().replace(/\/$/, '');
+			setStatus('Fetching…');
+			let info, ratesData, proposalsData, ranked;
+			try {
+				[info, ratesData, proposalsData, ranked] = await Promise.all([
+					fetchJson(`${base}/savings/core/info`),
+					fetchJson(`${base}/savings/leadrate/rates`),
+					fetchJson(`${base}/savings/leadrate/proposals`),
+					fetchJson(`${base}/savings/core/ranked`),
+				]);
+			} catch (e) {
+				setStatus('Error: ' + e.message, '#dc2626');
+				return;
+			}
+
+			setStatus('Loaded', '#16a34a');
+			renderStats(info);
+			renderStatusBlocks(info);
+			renderRatesChart(ratesData, proposalsData);
+			renderUnsyncedTable(ratesData);
+			renderRatesTable(ratesData);
+			renderProposalsTable(proposalsData);
+			renderRanked(ranked);
+		}
+
+		function renderStats(info) {
+			const totalBalance  = typeof info.totalBalance  === 'number' ? info.totalBalance  : 0;
+			const totalInterest = typeof info.totalInterest === 'number' ? info.totalInterest : 0;
+			const ratio         = typeof info.ratioOfSupply === 'number' ? info.ratioOfSupply : 0;
+			const rates = [];
+			for (const [chainId, modules] of Object.entries(info.status || {}))
+				for (const [, s] of Object.entries(modules))
+					rates.push(`${chainLabel(Number(chainId))}: ${ppm(s.rate)}`);
+
+			document.getElementById('stats').innerHTML = `
+				<span>Total Balance: <b>${totalBalance.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ZCHF</b></span>
+				<span>Total Interest: <b>${totalInterest.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ZCHF</b></span>
+				<span>Ratio of Supply: <b>${(ratio * 100).toFixed(2)}%</b></span>
+				<span>Rates: <b>${rates.join(' | ') || '—'}</b></span>
+			`;
+		}
+
+		function renderStatusBlocks(info) {
+			const container = document.getElementById('status-blocks');
+			container.innerHTML = '';
+			for (const [chainId, modules] of Object.entries(info.status || {})) {
+				for (const [module, s] of Object.entries(modules)) {
+					const block = document.createElement('div');
+					block.className = 'chain-block';
+					block.innerHTML = `
+						<h3>${seriesLabel(chainId, module)} — <span style="color:#2563eb" title="${module}">${shortAddr(module)}</span>
+							&nbsp;<span style="color:#888;font-size:0.75rem">updated ${ts(s.updated)}</span></h3>
+						<div class="grid-2">
+							<table>
+								<tr><th>Balance</th><td>${fmt(s.balance)} ZCHF</td></tr>
+								<tr><th>Total Saved</th><td>${fmt(s.save)} ZCHF</td></tr>
+								<tr><th>Total Withdrawn</th><td>${fmt(s.withdraw)} ZCHF</td></tr>
+								<tr><th>Total Interest</th><td>${fmt(s.interest)} ZCHF</td></tr>
+								<tr><th>Current Rate</th><td>${ppm(s.rate)} (${s.rate} PPM)</td></tr>
+							</table>
+							<table>
+								<tr><th>Save count</th><td>${s.counter.save}</td></tr>
+								<tr><th>Withdraw count</th><td>${s.counter.withdraw}</td></tr>
+								<tr><th>Interest count</th><td>${s.counter.interest}</td></tr>
+								<tr><th>Rate changes</th><td>${s.counter.rateChanged}</td></tr>
+								<tr><th>Rate proposals</th><td>${s.counter.rateProposed}</td></tr>
+							</table>
+						</div>
+					`;
+					container.appendChild(block);
+				}
+			}
+		}
+
+		function renderRatesChart(ratesData, proposalsData) {
+			const rateSeries = [];
+			for (const [chainId, modules] of Object.entries(ratesData.list || {})) {
+				if (Number(chainId) !== 1) continue;
+				for (const [module, entries] of Object.entries(modules)) {
+					rateSeries.push({
+						label: seriesLabel(chainId, module),
+						color: moduleColor(chainId, module),
+						entries: [...entries].sort((a, b) => a.created - b.created),
+					});
+				}
+			}
+
+			const proposalSeries = [];
+			for (const [chainId, modules] of Object.entries(proposalsData.list || {})) {
+				if (Number(chainId) !== 1) continue;
+				for (const [module, entries] of Object.entries(modules)) {
+					proposalSeries.push({
+						label: seriesLabel(chainId, module) + ' proposals',
+						color: moduleColor(chainId, module),
+						entries: [...entries].sort((a, b) => a.created - b.created),
+					});
+				}
+			}
+
+			const allDates = new Set();
+			for (const s of rateSeries)    s.entries.forEach(e => allDates.add(new Date(e.created * 1000).toISOString().slice(0, 10)));
+			for (const s of proposalSeries) s.entries.forEach(e => allDates.add(new Date(e.created * 1000).toISOString().slice(0, 10)));
+			const labels = [...allDates].sort();
+
+			const datasets = [];
+
+			for (const { label, color, entries } of rateSeries) {
+				const byDate = {};
+				entries.forEach(e => { byDate[new Date(e.created * 1000).toISOString().slice(0, 10)] = e; });
+				let last = null;
+				const data = labels.map(d => { if (byDate[d]) last = byDate[d]; return last ? last.approvedRate / 10000 : null; });
+				datasets.push({
+					label, data,
+					_entries: labels.map(d => byDate[d] || null),
+					borderColor: color,
+					backgroundColor: color + '18',
+					borderWidth: 2,
+					pointRadius: labels.map(d => (byDate[d] ? 4 : 0)),
+					pointBackgroundColor: color,
+					stepped: 'before', fill: false, tension: 0, spanGaps: true,
+				});
+			}
+
+			for (const { label, color, entries } of proposalSeries) {
+				const byDate = {};
+				entries.forEach(e => { byDate[new Date(e.created * 1000).toISOString().slice(0, 10)] = e; });
+				datasets.push({
+					label,
+					data: labels.map(d => (byDate[d] ? byDate[d].nextRate / 10000 : null)),
+					_entries: labels.map(d => byDate[d] || null),
+					borderColor: 'transparent',
+					pointRadius: labels.map(d => (byDate[d] ? 6 : 0)),
+					pointStyle: 'triangle',
+					pointBackgroundColor: color,
+					showLine: false, fill: false, spanGaps: true,
+				});
+			}
+
+			// Compute a clean Y max: find highest value across all datasets, then round up
+			// to the next "nice" step (0.5 if <5%, 1 if <20%, 5 if larger)
+			const allValues = datasets.flatMap(ds => ds.data.filter(v => v != null));
+			const rawMax = allValues.length ? Math.max(...allValues) : 10;
+			function niceMax(v) {
+				const step = v < 5 ? 0.5 : v < 20 ? 1 : 5;
+				return Math.ceil((v + step * 0.5) / step) * step;
+			}
+			const yMax = niceMax(rawMax);
+
+			if (chartRates) chartRates.destroy();
+			const ctx = document.getElementById('chart-rates').getContext('2d');
+			chartRates = new Chart(ctx, {
+				type: 'line',
+				data: { labels, datasets },
+				options: {
+					responsive: true, maintainAspectRatio: false, animation: false,
+					plugins: {
+						legend: { labels: { color: '#333', boxWidth: 12 } },
+						tooltip: {
+							backgroundColor: '#fff', titleColor: '#666',
+							bodyColor: '#111', borderColor: '#ddd', borderWidth: 1,
+							callbacks: {
+								title: (items) => labels[items[0].dataIndex],
+								label: (item) => {
+									const v = item.raw;
+									if (v === null) return null;
+									const e = item.dataset._entries?.[item.dataIndex];
+									const lines = [`${item.dataset.label}: ${v.toFixed(4)}%`];
+									if (e?.approvedRate !== undefined) lines.push(`  PPM: ${e.approvedRate}`, `  Tx: ${shortHash(e.txHash)}`);
+									if (e?.nextRate     !== undefined) lines.push(`  Proposed: ${(e.nextRate / 10000).toFixed(4)}%`, `  Effective: ${ts(e.nextChange)}`);
+									return lines;
+								},
+							},
+						},
+					},
+					scales: {
+						x: { ticks: { color: '#888', maxTicksLimit: 20, maxRotation: 45 }, grid: { color: '#ececec' } },
+						y: {
+							min: 0,
+							max: yMax,
+							ticks: { color: '#888', callback: v => v.toFixed(2) + '%' },
+							grid: { color: '#ececec' },
+							title: { display: true, text: 'Rate (%)', color: '#888' },
+						},
+					},
+				},
+			});
+		}
+
+		function renderUnsyncedTable(ratesData) {
+			const tbody = document.getElementById('unsynced-table');
+			const ethModules = ratesData.rate?.['1'] || ratesData.rate?.[1] || {};
+			let ethSavingsRate = null;
+			for (const [module, entry] of Object.entries(ethModules)) {
+				if (module.toLowerCase().startsWith('0x27')) { ethSavingsRate = entry.approvedRate; break; }
+			}
+			if (ethSavingsRate === null) {
+				tbody.innerHTML = '<tr><td colspan="8" style="color:#888;padding:8px 10px">ETH mainnet Savings rate not found</td></tr>';
+				return;
+			}
+			const unsynced = [];
+			for (const [chainId, modules] of Object.entries(ratesData.rate || {})) {
+				if (Number(chainId) === 1) continue;
+				for (const [module, entry] of Object.entries(modules))
+					if (entry.approvedRate !== ethSavingsRate)
+						unsynced.push({ chainId: Number(chainId), module, entry });
+			}
+			if (unsynced.length === 0) {
+				tbody.innerHTML = `<tr><td colspan="8" style="color:#16a34a;padding:8px 10px">All bridged savings modules are in sync with ETH mainnet rate (${ppm(ethSavingsRate)} / ${ethSavingsRate} PPM)</td></tr>`;
+				return;
+			}
+			tbody.innerHTML = unsynced.map(u => {
+				const delta = u.entry.approvedRate - ethSavingsRate;
+				const dc    = delta > 0 ? '#16a34a' : '#dc2626';
+				return `<tr>
+					<td><span class="tag tag-blue">${chainLabel(u.chainId)}</span></td>
+					<td style="color:#888" title="${u.module}">${shortAddr(u.module)}</td>
+					<td>${u.entry.approvedRate}</td>
+					<td>${ppm(u.entry.approvedRate)}</td>
+					<td style="color:#555">${ppm(ethSavingsRate)} (${ethSavingsRate} PPM)</td>
+					<td style="color:${dc}">${delta > 0 ? '+' : ''}${delta} PPM</td>
+					<td>${ts(u.entry.created)}</td>
+					<td style="color:#aaa" title="${u.entry.txHash}">${shortHash(u.entry.txHash)}</td>
+				</tr>`;
+			}).join('');
+		}
+
+		function renderRatesTable(ratesData) {
+			const all = [];
+			for (const [chainId, modules] of Object.entries(ratesData.list || {}))
+				for (const [module, entries] of Object.entries(modules))
+					entries.forEach(e => all.push({ ...e, chainId: Number(chainId), module }));
+			all.sort((a, b) => a.created - b.created);
+
+			const prevRate = {};
+			const tbody = document.getElementById('rates-table');
+			tbody.innerHTML = all.length === 0
+				? '<tr><td colspan="8" style="color:#888;padding:8px 10px">No data</td></tr>'
+				: all.map((e, i) => {
+					const key   = `${e.chainId}:${e.module}`;
+					const prev  = prevRate[key];
+					const delta = prev !== undefined ? e.approvedRate - prev : null;
+					prevRate[key] = e.approvedRate;
+					const deltaStr = delta === null ? '—' : (delta > 0 ? '+' : '') + (delta / 10000).toFixed(4) + '%';
+					const dc       = delta === null ? '#888' : delta > 0 ? '#16a34a' : delta < 0 ? '#dc2626' : '#888';
+					const modLabel = moduleLabel(e.chainId, e.module);
+					const modClass = modLabel === 'Savings' ? 'tag-green' : modLabel === 'Mint Rate' ? 'tag-yellow' : 'tag-gray';
+					return `<tr>
+						<td>${i + 1}</td>
+						<td>${ts(e.created)}</td>
+						<td><span class="tag tag-blue">${chainLabel(e.chainId)}</span></td>
+						<td><span class="tag ${modClass}" title="${e.module}">${modLabel}</span></td>
+						<td>${e.approvedRate}</td>
+						<td>${ppm(e.approvedRate)}</td>
+						<td style="color:${dc}">${deltaStr}</td>
+						<td style="color:#aaa" title="${e.txHash}">${shortHash(e.txHash)}</td>
+					</tr>`;
+				}).join('');
+		}
+
+		function renderProposalsTable(proposalsData) {
+			const all = [];
+			for (const [chainId, modules] of Object.entries(proposalsData.list || {}))
+				for (const [module, entries] of Object.entries(modules))
+					entries.forEach(e => all.push({ ...e, chainId: Number(chainId), module }));
+			all.sort((a, b) => a.created - b.created);
+
+			const now   = Math.floor(Date.now() / 1000);
+			const tbody = document.getElementById('proposals-table');
+			tbody.innerHTML = all.length === 0
+				? '<tr><td colspan="9" style="color:#888;padding:8px 10px">No data</td></tr>'
+				: all.map((e, i) => {
+					const isPending = e.nextChange > now;
+					const badge     = isPending
+						? '<span class="tag tag-yellow">Pending</span>'
+						: '<span class="tag tag-gray">Executed</span>';
+					const modLabel = moduleLabel(e.chainId, e.module);
+					const modClass = modLabel === 'Savings' ? 'tag-green' : modLabel === 'Mint Rate' ? 'tag-yellow' : 'tag-gray';
+					return `<tr>
+						<td>${i + 1}</td>
+						<td>${ts(e.created)}</td>
+						<td><span class="tag tag-blue">${chainLabel(e.chainId)}</span></td>
+						<td><span class="tag ${modClass}" title="${e.module}">${modLabel}</span></td>
+						<td>${e.nextRate}</td>
+						<td>${ppm(e.nextRate)}</td>
+						<td>${ts(e.nextChange)} ${badge}</td>
+						<td style="color:#aaa" title="${e.proposer}">${shortAddr(e.proposer)}</td>
+						<td style="color:#aaa" title="${e.txHash}">${shortHash(e.txHash)}</td>
+					</tr>`;
+				}).join('');
+		}
+
+		function renderRanked(ranked) {
+			if (!Array.isArray(ranked)) return;
+			const tbody = document.getElementById('ranked-table');
+			tbody.innerHTML = ranked.slice(0, 20).length === 0
+				? '<tr><td colspan="8" style="color:#888;padding:8px 10px">No data</td></tr>'
+				: ranked.slice(0, 20).map((r, i) => `<tr>
+					<td>${i + 1}</td>
+					<td style="color:#2563eb" title="${r.account}">${shortAddr(r.account)}</td>
+					<td><span class="tag tag-blue">${chainLabel(r.chainId)}</span></td>
+					<td>${fmt(r.balance)}</td>
+					<td>${fmt(r.save)}</td>
+					<td style="color:#16a34a">${fmt(r.interest)}</td>
+					<td style="color:#dc2626">${fmt(r.withdraw)}</td>
+					<td style="color:#aaa">${ts(r.updated)}</td>
+				</tr>`).join('');
+		}
+
+		load();
+		</script>
+	</body>
+</html>

--- a/scripts/send-telegram-mocks.ts
+++ b/scripts/send-telegram-mocks.ts
@@ -1,0 +1,373 @@
+#!/usr/bin/env ts-node
+/**
+ * Send all Telegram message mocks to a target chat.
+ *
+ * Usage:
+ *   yarn telegram:mocks
+ *   TELEGRAM_TEST_CHAT_ID=<id> yarn telegram:mocks
+ *   ts-node -r tsconfig-paths/register scripts/send-telegram-mocks.ts [chatId]
+ */
+
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+import TelegramBot from 'node-telegram-bot-api';
+import { WelcomeGroupMessage } from '../src/integrations/telegram/messages/WelcomeGroup.message';
+import { HelpMessage } from '../src/integrations/telegram/messages/Help.message';
+import { StartUpMessage } from '../src/integrations/telegram/messages/StartUp.message';
+import { MinterProposalMessage } from '../src/integrations/telegram/messages/MinterProposal.message';
+import { MinterProposalVetoedMessage } from '../src/integrations/telegram/messages/MinterProposalVetoed.message';
+import { LeadrateProposalMessage } from '../src/integrations/telegram/messages/LeadrateProposal.message';
+import { LeadrateChangedMessage } from '../src/integrations/telegram/messages/LeadrateChanged.message';
+import { PositionProposalMessage } from '../src/integrations/telegram/messages/PositionProposal.message';
+import { PositionDeniedMessage } from '../src/integrations/telegram/messages/PositionDenied.message';
+import { PositionExpiringSoonMessage } from '../src/integrations/telegram/messages/PositionExpiringSoon.message';
+import { PositionExpiredMessage } from '../src/integrations/telegram/messages/PositionExpired.message';
+import { PositionPriceLowest, PositionPriceAlert, PositionPriceWarning } from '../src/integrations/telegram/messages/PositionPrice.message';
+import { ChallengeStartedMessage } from '../src/integrations/telegram/messages/ChallengeStarted.message';
+import { BidTakenMessage } from '../src/integrations/telegram/messages/BidTaken.message';
+import { MintingUpdateMessage } from '../src/integrations/telegram/messages/MintingUpdate.message';
+import { EquityInvestedMessage } from '../src/integrations/telegram/messages/EquityInvested.message';
+import { EquityRedeemedMessage } from '../src/integrations/telegram/messages/EquityRedeemed.message';
+import { DailyInfosMessage } from '../src/integrations/telegram/messages/DailyInfos.message';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const CHAT_ID = process.argv[2] || process.env.TELEGRAM_TEST_CHAT_ID;
+
+if (!BOT_TOKEN) {
+	console.error('❌  TELEGRAM_BOT_TOKEN is not set');
+	process.exit(1);
+}
+if (!CHAT_ID) {
+	console.error('❌  Provide a chat ID: TELEGRAM_TEST_CHAT_ID=<id> yarn telegram:mocks  or pass as first argument');
+	process.exit(1);
+}
+
+const bot = new TelegramBot(BOT_TOKEN);
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+const now = Math.floor(Date.now() / 1000);
+const ADDR_POS = '0xabc123def456abc123def456abc123def456abc1' as any;
+const ADDR_OWNER = '0xbbb222ccc333ddd444eee555fff666aaa777bbb2' as any;
+const ADDR_COL = '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599' as any;
+const ADDR_MINTER = '0xdead000beef000dead000beef000dead000beef00' as any;
+const ADDR_SUGGEST = '0xcafe111babe222cafe111babe222cafe111babe22' as any;
+const ADDR_VETOR = '0x1111222233334444555566667777888899990000' as any;
+const ADDR_CHALLENGER = '0xf00dface000deadbeef0000f00dface000deadbe0' as any;
+const ADDR_BIDDER = '0x9999888877776666555544443333222211110000' as any;
+const TX_HASH = '0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aa';
+const MODULE = '0x1234567890abcdef1234567890abcdef12345678' as any;
+
+const mockPosition: any = {
+	version: 2,
+	position: ADDR_POS,
+	owner: ADDR_OWNER,
+	zchf: '0x0000000000000000000000000000000000000000' as any,
+	collateral: ADDR_COL,
+	price: (45000n * 10n ** 36n / 10n ** 8n).toString(), // 45000 ZCHF per 1e-8 BTC unit → 36-8=28 decimals
+	created: now - 86400 * 30,
+	isOriginal: true,
+	isClone: false,
+	denied: false,
+	denyDate: 0,
+	closed: false,
+	original: ADDR_POS,
+	parent: ADDR_POS,
+	minimumCollateral: (1n * 10n ** 7n).toString(),         // 0.1 WBTC (8 decimals)
+	annualInterestPPM: 50000,                                // 5%
+	riskPremiumPPM: 20000,
+	reserveContribution: 100000,                             // 10%
+	start: now - 86400 * 10,
+	cooldown: now - 86400 * 5,
+	expiration: now + 86400,                                 // expires in 1 day
+	challengePeriod: 86400,                                  // 24h
+	zchfName: 'Frankencoin',
+	zchfSymbol: 'ZCHF',
+	zchfDecimals: 18,
+	collateralName: 'Wrapped BTC',
+	collateralSymbol: 'WBTC',
+	collateralDecimals: 8,
+	collateralBalance: (15n * 10n ** 7n).toString(),        // 1.5 WBTC
+	limitForPosition: (100000n * 10n ** 18n).toString(),
+	limitForClones: (100000n * 10n ** 18n).toString(),
+	availableForPosition: (50000n * 10n ** 18n).toString(),
+	availableForClones: (50000n * 10n ** 18n).toString(),
+	availableForMinting: (50000n * 10n ** 18n).toString(),
+	minted: (50000n * 10n ** 18n).toString(),
+};
+
+const mockMinter: any = {
+	chainId: 1,
+	txHash: TX_HASH,
+	minter: ADDR_MINTER,
+	applicationPeriod: 7 * 24 * 3600,
+	applicationFee: 1000e18,
+	applyMessage: 'New collateral type for the Frankencoin ecosystem',
+	applyDate: now - 3600,
+	suggestor: ADDR_SUGGEST,
+	denyMessage: 'Does not meet requirements',
+	denyDate: now - 1800,
+	denyTxHash: TX_HASH,
+	vetor: ADDR_VETOR,
+};
+
+const mockLeadrateRate: any = {
+	chainId: 1,
+	created: now - 3600,
+	count: 5,
+	blockheight: 19_000_000,
+	module: MODULE,
+	approvedRate: 30000, // 3%
+	txHash: TX_HASH,
+};
+
+const mockLeadrateProposal: any = {
+	chainId: 1,
+	created: now - 3600,
+	count: 6,
+	blockheight: 19_000_001,
+	module: MODULE,
+	txHash: TX_HASH,
+	proposer: ADDR_SUGGEST,
+	nextRate: 40000, // 4%
+	nextChange: now + 7 * 24 * 3600,
+};
+
+const mockChallenge: any = {
+	version: 2,
+	id: `${ADDR_POS}-challenge-1` as any,
+	position: ADDR_POS,
+	number: 1n,
+	txHash: TX_HASH as any,
+	challenger: ADDR_CHALLENGER,
+	start: BigInt(now - 3600),
+	created: BigInt(now - 3600),
+	duration: BigInt(86400),
+	size: (10n * 10n ** 7n),  // 1.0 WBTC
+	liqPrice: (45000n * 10n ** 28n), // 45000 ZCHF per WBTC (36-8=28 decimals)
+	bids: 0n,
+	filledSize: 0n,
+	acquiredCollateral: 0n,
+	status: 'Active' as any,
+};
+
+const mockBid: any = {
+	version: 2,
+	id: `${ADDR_POS}-bid-1` as any,
+	position: ADDR_POS,
+	number: 1n,
+	numberBid: 0n,
+	txHash: TX_HASH as any,
+	bidder: ADDR_BIDDER,
+	created: BigInt(now - 1800),
+	bidType: 'Averted',
+	bid: 54000n * 10n ** 18n,
+	price: 45000n * 10n ** 28n,
+	filledSize: 12n * 10n ** 7n,  // 1.2 WBTC
+	acquiredCollateral: 12n * 10n ** 7n,
+	challengeSize: 15n * 10n ** 7n, // 1.5 WBTC
+};
+
+const mockMinting: any = {
+	version: 1,
+	id: `${ADDR_POS}-1` as any,
+	count: 1,
+	txHash: TX_HASH,
+	created: now - 3600,
+	position: ADDR_POS,
+	owner: ADDR_OWNER,
+	isClone: false,
+	collateral: ADDR_COL,
+	collateralName: 'Wrapped BTC',
+	collateralSymbol: 'WBTC',
+	collateralDecimals: 8,
+	size: (15n * 10n ** 7n).toString(),
+	price: (45000n * 10n ** 28n).toString(),
+	minted: (50000n * 10n ** 18n).toString(),
+	sizeAdjusted: (5n * 10n ** 7n).toString(),
+	priceAdjusted: (45000n * 10n ** 28n).toString(),
+	mintedAdjusted: (10000n * 10n ** 18n).toString(), // +10000 ZCHF minted
+	annualInterestPPM: 50000,
+	reserveContribution: 100000,
+	feeTimeframe: 30 * 86400,
+	feePPM: 4110,
+	feePaid: (50n * 10n ** 18n).toString(),
+};
+
+const mockPrices: any = {
+	[ADDR_COL.toLowerCase()]: {
+		chainId: 1,
+		address: ADDR_COL,
+		name: 'Wrapped BTC',
+		symbol: 'WBTC',
+		decimals: 8,
+		source: 'coingecko',
+		timestamp: now,
+		price: { usd: 48600, chf: 43200 }, // ~96% collateralized at 45000 liq price
+	},
+};
+
+const mockPricesUndercol: any = {
+	[ADDR_COL.toLowerCase()]: {
+		...mockPrices[ADDR_COL.toLowerCase()],
+		price: { usd: 43000, chf: 43900 }, // below 100%
+	},
+};
+
+const mockPricesAlert: any = {
+	[ADDR_COL.toLowerCase()]: {
+		...mockPrices[ADDR_COL.toLowerCase()],
+		price: { usd: 46500, chf: 46500 }, // ~103% → alert
+	},
+};
+
+const mockPriceState: any = {
+	warningPrice: 0,
+	warningTimestamp: 0,
+	alertPrice: 0,
+	alertTimestamp: 0,
+	lowestPrice: 0,
+	lowestTimestamp: 0,
+};
+
+const mockEquityLog: any = {
+	chainId: 1,
+	count: 1,
+	timestamp: String(now - 600),
+	kind: 'Equity:Invested',
+	amount: 15000n * 10n ** 18n,
+	txHash: TX_HASH,
+	totalInflow: 0n,
+	totalOutflow: 0n,
+	totalTradeFee: 0n,
+	totalSupply: 1_200_000n * 10n ** 18n,
+	totalEquity: 24_000_000n * 10n ** 18n,
+	totalSavings: 300_000n * 10n ** 18n,
+	fpsTotalSupply: 20000n * 10n ** 18n,
+	fpsPrice: 1200n * 10n ** 18n,
+	totalMintedV1: 0n,
+	totalMintedV2: 0n,
+	currentMintLeadRate: 0n,
+	currentSaveLeadRate: 0n,
+	projectedInterests: 0n,
+	annualV1Interests: 0n,
+	annualV2Interests: 0n,
+	annualV1BorrowRate: 0n,
+	annualV2BorrowRate: 0n,
+	annualNetEarnings: 0n,
+	realizedNetEarnings: 0n,
+	earningsPerFPS: 0n,
+};
+
+const mockDailyBefore: any = {
+	date: new Date(Date.now() - 30 * 86400 * 1000).toISOString().split('T')[0],
+	timestamp: String(now - 30 * 86400),
+	txHash: TX_HASH,
+	totalInflow: 0n,
+	totalOutflow: 0n,
+	totalTradeFee: 0n,
+	totalSupply: 1_100_000n * 10n ** 18n,
+	totalEquity: 22_000_000n * 10n ** 18n,
+	totalSavings: 250_000n * 10n ** 18n,
+	fpsTotalSupply: 19000n * 10n ** 18n,
+	fpsPrice: 1140n * 10n ** 18n,
+	totalMintedV1: 0n,
+	totalMintedV2: 0n,
+	currentMintLeadRate: 0n,
+	currentSaveLeadRate: 0n,
+	projectedInterests: 0n,
+	annualV1Interests: 0n,
+	annualV2Interests: 0n,
+	annualV1BorrowRate: 0n,
+	annualV2BorrowRate: 0n,
+	annualNetEarnings: 0n,
+	realizedNetEarnings: 0n,
+	earningsPerFPS: 0n,
+};
+
+const mockDailyNow: any = {
+	...mockDailyBefore,
+	date: new Date().toISOString().split('T')[0],
+	timestamp: String(now),
+	totalSupply: 1_200_000n * 10n ** 18n,
+	totalEquity: 24_000_000n * 10n ** 18n,
+	totalSavings: 300_000n * 10n ** 18n,
+	fpsPrice: 1200n * 10n ** 18n,
+};
+
+// Supply keys are seconds; we need entries clearly before each 'date' string in the daily logs
+// Use keys that are a few days older than the daily log dates so the filter finds them
+const keyBefore = now - 35 * 86400; // 35 days ago
+const keyAfter = now - 1 * 86400;   // yesterday
+const mockSupply: any = {
+	[keyBefore]: { supply: 1_100_000, created: keyBefore, allocation: {} },
+	[keyAfter]: { supply: 1_200_000, created: keyAfter, allocation: {} },
+};
+
+// ---------------------------------------------------------------------------
+// Messages to send
+// ---------------------------------------------------------------------------
+const handles = ['/MintingUpdates', '/PriceAlerts', '/DailyInfos', '/help'];
+const chatSubs = { MintingUpdates: true, PriceAlerts: false, DailyInfos: true };
+
+const messages: Array<{ label: string; text: string }> = [
+	{ label: 'WelcomeGroup', text: WelcomeGroupMessage(CHAT_ID, handles) },
+	{ label: 'Help', text: HelpMessage(handles, chatSubs) },
+	{ label: 'StartUp', text: StartUpMessage(handles) },
+	{ label: 'MinterProposal', text: MinterProposalMessage(mockMinter) },
+	{ label: 'MinterProposalVetoed', text: MinterProposalVetoedMessage(mockMinter) },
+	{ label: 'LeadrateProposal', text: LeadrateProposalMessage(mockLeadrateProposal, [mockLeadrateRate]) },
+	{ label: 'LeadrateChanged', text: LeadrateChangedMessage(mockLeadrateRate) },
+	{ label: 'PositionProposal', text: PositionProposalMessage({ ...mockPosition, start: now + 86400 }) },
+	{ label: 'PositionDenied', text: PositionDeniedMessage({ ...mockPosition, denied: true, denyDate: now - 3600 }) },
+	{ label: 'PositionExpiringSoon', text: PositionExpiringSoonMessage(mockPosition) },
+	{ label: 'PositionExpired (v1)', text: PositionExpiredMessage({ ...mockPosition, version: 1, expiration: now - 3600 }) },
+	{ label: 'PositionExpired (v2)', text: PositionExpiredMessage({ ...mockPosition, expiration: now - 3600 }) },
+	{ label: 'PriceWarning', text: PositionPriceWarning(mockPosition, mockPrices[ADDR_COL.toLowerCase()], mockPriceState) },
+	{ label: 'PriceAlert', text: PositionPriceAlert(mockPosition, mockPricesAlert[ADDR_COL.toLowerCase()], mockPriceState) },
+	{ label: 'PriceLowest', text: PositionPriceLowest(mockPosition, mockPricesUndercol[ADDR_COL.toLowerCase()], mockPriceState) },
+	{ label: 'ChallengeStarted', text: ChallengeStartedMessage(mockPosition, mockChallenge) },
+	{ label: 'BidTaken', text: BidTakenMessage(mockPosition, mockChallenge, mockBid) },
+	{ label: 'MintingUpdate', text: MintingUpdateMessage(mockMinting, mockPrices) },
+	{ label: 'EquityInvested', text: EquityInvestedMessage(mockEquityLog) },
+	{ label: 'EquityRedeemed', text: EquityRedeemedMessage({ ...mockEquityLog, kind: 'Equity:Redeemed' }) },
+	{ label: 'DailyInfos', text: DailyInfosMessage(mockDailyBefore, mockDailyNow, mockSupply) },
+];
+
+// ---------------------------------------------------------------------------
+// Send
+// ---------------------------------------------------------------------------
+async function send(label: string, text: string) {
+	try {
+		await bot.sendMessage(CHAT_ID, text, { parse_mode: 'Markdown', disable_web_page_preview: true });
+		console.log(`✅  ${label}`);
+	} catch (err) {
+		console.error(`❌  ${label}: ${err.message}`);
+		console.error('    Message preview:', text.slice(0, 120).replace(/\n/g, ' '));
+	}
+}
+
+async function main() {
+	console.log(`\n📤  Sending ${messages.length} mock messages to chat ${CHAT_ID}\n`);
+
+	// Section header
+	await send('— header —', `🧪 *Telegram Mock Preview*\n\n${messages.length} message types — one per section below.`);
+
+	for (const { label, text } of messages) {
+		await new Promise((r) => setTimeout(r, 400)); // avoid hitting rate limit
+		await send(label, text);
+	}
+
+	console.log('\n✅  Done\n');
+	process.exit(0);
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/scripts/totalsupply-debug.html
+++ b/scripts/totalsupply-debug.html
@@ -5,111 +5,53 @@
 		<title>ZCHF Total Supply Debug</title>
 		<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 		<style>
-			* {
-				box-sizing: border-box;
-				margin: 0;
-				padding: 0;
-			}
-			body {
-				font-family: monospace;
-				background: #0f0f0f;
-				color: #e0e0e0;
-				padding: 20px;
-			}
-			h1 {
-				font-size: 1.2rem;
-				margin-bottom: 12px;
-				color: #fff;
-			}
+			* { box-sizing: border-box; margin: 0; padding: 0; }
+			body { font-family: monospace; background: #f5f5f5; color: #111; padding: 20px; }
+			h1 { font-size: 1.2rem; margin-bottom: 12px; color: #000; }
 			#controls {
-				display: flex;
-				gap: 12px;
-				align-items: center;
-				margin-bottom: 16px;
-				flex-wrap: wrap;
+				display: flex; gap: 12px; align-items: center;
+				margin-bottom: 16px; flex-wrap: wrap;
 			}
-			#api-url {
-				flex: 1;
-				min-width: 320px;
-				background: #1c1c1c;
-				border: 1px solid #333;
-				color: #e0e0e0;
-				padding: 6px 10px;
-				border-radius: 4px;
-				font-family: monospace;
+			#base-url {
+				flex: 1; min-width: 320px;
+				background: #fff; border: 1px solid #ccc;
+				color: #111; padding: 6px 10px;
+				border-radius: 4px; font-family: monospace;
 			}
 			button {
-				background: #2563eb;
-				color: #fff;
-				border: none;
-				padding: 7px 16px;
-				border-radius: 4px;
-				cursor: pointer;
-				font-family: monospace;
+				background: #2563eb; color: #fff; border: none;
+				padding: 7px 16px; border-radius: 4px; cursor: pointer; font-family: monospace;
 			}
-			button:hover {
-				background: #1d4ed8;
-			}
-			#status {
-				font-size: 0.8rem;
-				color: #888;
-			}
+			button:hover { background: #1d4ed8; }
+			#status { font-size: 0.8rem; color: #666; }
 			#chart-container {
-				position: relative;
-				width: 100%;
-				height: 480px;
-				background: #161616;
-				border-radius: 6px;
-				padding: 16px;
+				position: relative; width: 100%; height: 480px;
+				background: #fff; border-radius: 6px; padding: 16px;
+				border: 1px solid #e0e0e0;
 			}
-			#anomalies {
-				margin-top: 20px;
-			}
-			#anomalies h2 {
-				font-size: 1rem;
-				margin-bottom: 8px;
-				color: #f59e0b;
-			}
-			table {
-				width: 100%;
-				border-collapse: collapse;
-				font-size: 0.78rem;
-			}
+			#anomalies { margin-top: 20px; }
+			#anomalies h2 { font-size: 1rem; margin-bottom: 8px; color: #a16207; }
+			table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
 			th {
-				text-align: left;
-				padding: 6px 10px;
-				background: #1c1c1c;
-				color: #aaa;
-				border-bottom: 1px solid #333;
+				text-align: left; padding: 6px 10px;
+				background: #f0f0f0; color: #444;
+				border-bottom: 1px solid #ddd;
 			}
-			td {
-				padding: 5px 10px;
-				border-bottom: 1px solid #1e1e1e;
-			}
-			tr.spike {
-				color: #f87171;
-			}
-			tr.gap {
-				color: #fb923c;
-			}
+			td { padding: 5px 10px; border-bottom: 1px solid #eee; }
+			tr.spike { color: #dc2626; }
+			tr.gap   { color: #ea580c; }
 			#stats {
-				display: flex;
-				gap: 20px;
-				flex-wrap: wrap;
-				margin-bottom: 14px;
-				font-size: 0.82rem;
-				color: #aaa;
+				display: flex; gap: 20px; flex-wrap: wrap;
+				margin-bottom: 14px; font-size: 0.82rem; color: #555;
 			}
-			#stats span b {
-				color: #e0e0e0;
-			}
+			#stats span b { color: #111; }
 		</style>
 	</head>
 	<body>
 		<h1>ZCHF Total Supply — Anomalies Chart</h1>
 
 		<div id="controls">
-			<input id="api-url" type="text" value="https://api.frankencoin.com/ecosystem/frankencoin/totalsupply" />
+			<input id="base-url" type="text" value="https://api.frankencoin.com" />
 			<button onclick="load()">Load</button>
 			<span id="status"></span>
 		</div>
@@ -138,157 +80,133 @@
 		</div>
 
 		<script>
-			let chartInstance = null;
+		let chartInstance = null;
 
-			function setStatus(msg, color) {
-				const el = document.getElementById('status');
-				el.textContent = msg;
-				el.style.color = color || '#888';
+		function setStatus(msg, color) {
+			const el = document.getElementById('status');
+			el.textContent = msg;
+			el.style.color = color || '#666';
+		}
+
+		async function load() {
+			const base = document.getElementById('base-url').value.trim().replace(/\/$/, '');
+			const url = `${base}/ecosystem/frankencoin/totalsupply`;
+			setStatus('Fetching…');
+			let raw;
+			try {
+				const res = await fetch(url);
+				if (!res.ok) throw new Error(`HTTP ${res.status}`);
+				raw = await res.json();
+			} catch (e) {
+				setStatus('Error: ' + e.message, '#dc2626');
+				return;
 			}
 
-			async function load() {
-				const url = document.getElementById('api-url').value.trim();
-				setStatus('Fetching…');
-				let raw;
-				try {
-					const res = await fetch(url);
-					if (!res.ok) throw new Error(`HTTP ${res.status}`);
-					raw = await res.json();
-				} catch (e) {
-					setStatus('Error: ' + e.message, '#f87171');
-					return;
+			const entries = Object.values(raw).sort((a, b) => a.created - b.created);
+			setStatus(`Loaded ${entries.length} entries`, '#16a34a');
+
+			const labels   = entries.map((e) => new Date(e.created * 1000).toISOString().slice(0, 10));
+			const supplies = entries.map((e) => e.supply);
+
+			const deltas     = supplies.map((v, i) => (i === 0 ? 0 : v - supplies[i - 1]));
+			const absDeltas  = deltas.slice(1).map(Math.abs).sort((a, b) => a - b);
+			const median     = absDeltas[Math.floor(absDeltas.length / 2)] || 1;
+			const MAD_THRESH = Math.max(median * 10, supplies[supplies.length - 1] * 0.1);
+
+			const anomalies = [];
+			for (let i = 1; i < entries.length; i++) {
+				const dt = entries[i].created - entries[i - 1].created;
+				const dv = deltas[i];
+				const isSpike   = Math.abs(dv) > MAD_THRESH;
+				const isGap     = dt > 86400 * 2;
+				const isNonMono = dt <= 0;
+				if (isSpike || isGap || isNonMono) {
+					anomalies.push({
+						idx: i, ts: entries[i].created, date: labels[i],
+						supply: entries[i].supply, delta: dv, dt,
+						type: isNonMono ? 'NON-MONOTONIC' : isSpike ? 'SPIKE' : 'GAP',
+					});
 				}
+			}
 
-				// Sort by unix timestamp
-				const entries = Object.values(raw).sort((a, b) => a.created - b.created);
-				setStatus(`Loaded ${entries.length} entries`, '#4ade80');
+			document.getElementById('stats').innerHTML = `
+				<span>Entries: <b>${entries.length}</b></span>
+				<span>First: <b>${labels[0]}</b></span>
+				<span>Last: <b>${labels[labels.length - 1]}</b></span>
+				<span>Min supply: <b>${Math.min(...supplies).toFixed(2)}</b></span>
+				<span>Max supply: <b>${Math.max(...supplies).toFixed(2)}</b></span>
+				<span>Anomalies: <b style="color:${anomalies.length ? '#dc2626' : '#16a34a'}">${anomalies.length}</b></span>
+			`;
 
-				const labels = entries.map((e) => new Date(e.created * 1000).toISOString().slice(0, 10));
-				const supplies = entries.map((e) => e.supply);
+			const tbody = document.getElementById('anomaly-table');
+			tbody.innerHTML = anomalies.length === 0
+				? '<tr><td colspan="6" style="color:#16a34a;padding:8px 10px">None detected</td></tr>'
+				: anomalies.map((a, n) => `
+					<tr class="${a.type === 'SPIKE' ? 'spike' : 'gap'}">
+						<td>${n + 1}</td>
+						<td>${a.ts}</td>
+						<td>${a.date}</td>
+						<td>${a.supply.toFixed(4)}</td>
+						<td>${a.delta > 0 ? '+' : ''}${a.delta.toFixed(4)}</td>
+						<td>${a.type}</td>
+					</tr>`).join('');
 
-				// Gap / spike detection
-				const deltas = supplies.map((v, i) => (i === 0 ? 0 : v - supplies[i - 1]));
-				const absDeltas = deltas
-					.slice(1)
-					.map(Math.abs)
-					.sort((a, b) => a - b);
-				const median = absDeltas[Math.floor(absDeltas.length / 2)] || 1;
-				const MAD_THRESH = Math.max(median * 10, supplies[supplies.length - 1] * 0.1);
+			const pointColors = supplies.map((_, i) => {
+				const a = anomalies.find((x) => x.idx === i);
+				if (!a) return 'rgba(0,0,0,0)';
+				return a.type === 'SPIKE' ? '#dc2626' : '#ea580c';
+			});
+			const pointRadius = supplies.map((_, i) => (anomalies.find((x) => x.idx === i) ? 5 : 0));
 
-				const anomalies = [];
-				for (let i = 1; i < entries.length; i++) {
-					const dt = entries[i].created - entries[i - 1].created;
-					const dv = deltas[i];
-					const isSpike = Math.abs(dv) > MAD_THRESH;
-					const isGap = dt > 86400 * 2;
-					const isNonMono = dt <= 0;
-					if (isSpike || isGap || isNonMono) {
-						anomalies.push({
-							idx: i,
-							ts: entries[i].created,
-							date: labels[i],
-							supply: entries[i].supply,
-							delta: dv,
-							dt,
-							type: isNonMono ? 'NON-MONOTONIC' : isSpike ? 'SPIKE' : 'GAP',
-						});
-					}
-				}
-
-				// Stats
-				document.getElementById('stats').innerHTML = `
-    <span>Entries: <b>${entries.length}</b></span>
-    <span>First: <b>${labels[0]}</b></span>
-    <span>Last: <b>${labels[labels.length - 1]}</b></span>
-    <span>Min supply: <b>${Math.min(...supplies).toFixed(2)}</b></span>
-    <span>Max supply: <b>${Math.max(...supplies).toFixed(2)}</b></span>
-    <span>Anomalies: <b style="color:${anomalies.length ? '#f87171' : '#4ade80'}">${anomalies.length}</b></span>
-  `;
-
-				// Anomaly table
-				const tbody = document.getElementById('anomaly-table');
-				tbody.innerHTML =
-					anomalies.length === 0
-						? '<tr><td colspan="6" style="color:#4ade80;padding:8px 10px">None detected</td></tr>'
-						: anomalies
-								.map(
-									(a, n) => `
-        <tr class="${a.type === 'SPIKE' ? 'spike' : 'gap'}">
-          <td>${n + 1}</td>
-          <td>${a.ts}</td>
-          <td>${a.date}</td>
-          <td>${a.supply.toFixed(4)}</td>
-          <td>${a.delta > 0 ? '+' : ''}${a.delta.toFixed(4)}</td>
-          <td>${a.type}</td>
-        </tr>`
-								)
-								.join('');
-
-				// Highlight anomaly points on chart
-				const pointColors = supplies.map((_, i) => {
-					const a = anomalies.find((x) => x.idx === i);
-					if (!a) return 'rgba(0,0,0,0)';
-					return a.type === 'SPIKE' ? '#f87171' : '#fb923c';
-				});
-				const pointRadius = supplies.map((_, i) => (anomalies.find((x) => x.idx === i) ? 5 : 0));
-
-				if (chartInstance) chartInstance.destroy();
-				const ctx = document.getElementById('chart').getContext('2d');
-				chartInstance = new Chart(ctx, {
-					type: 'line',
-					data: {
-						labels,
-						datasets: [
-							{
-								label: 'Total Supply (ZCHF)',
-								data: supplies,
-								borderColor: '#3b82f6',
-								backgroundColor: 'rgba(59,130,246,0.08)',
-								borderWidth: 1.5,
-								pointRadius,
-								pointBackgroundColor: pointColors,
-								tension: 0,
-								fill: true,
-							},
-						],
-					},
-					options: {
-						responsive: true,
-						maintainAspectRatio: false,
-						animation: false,
-						plugins: {
-							legend: { labels: { color: '#aaa' } },
-							tooltip: {
-								callbacks: {
-									title: (items) => {
-										const i = items[0].dataIndex;
-										return `${labels[i]}  (unix: ${entries[i].created})`;
-									},
-									afterBody: (items) => {
-										const i = items[0].dataIndex;
-										const alloc = entries[i].allocation;
-										return Object.entries(alloc)
-											.filter(([, v]) => v > 0)
-											.map(([k, v]) => `  chain ${k}: ${v.toFixed(2)}`);
-									},
+			if (chartInstance) chartInstance.destroy();
+			const ctx = document.getElementById('chart').getContext('2d');
+			chartInstance = new Chart(ctx, {
+				type: 'line',
+				data: {
+					labels,
+					datasets: [{
+						label: 'Total Supply (ZCHF)',
+						data: supplies,
+						borderColor: '#2563eb',
+						backgroundColor: 'rgba(37,99,235,0.07)',
+						borderWidth: 1.5,
+						pointRadius,
+						pointBackgroundColor: pointColors,
+						tension: 0,
+						fill: true,
+					}],
+				},
+				options: {
+					responsive: true, maintainAspectRatio: false, animation: false,
+					plugins: {
+						legend: { labels: { color: '#333', boxWidth: 12 } },
+						tooltip: {
+							backgroundColor: '#fff', titleColor: '#666',
+							bodyColor: '#111', borderColor: '#ddd', borderWidth: 1,
+							callbacks: {
+								title: (items) => {
+									const i = items[0].dataIndex;
+									return `${labels[i]}  (unix: ${entries[i].created})`;
+								},
+								afterBody: (items) => {
+									const i = items[0].dataIndex;
+									const alloc = entries[i].allocation;
+									return Object.entries(alloc)
+										.filter(([, v]) => v > 0)
+										.map(([k, v]) => `  chain ${k}: ${v.toFixed(2)}`);
 								},
 							},
 						},
-						scales: {
-							x: {
-								ticks: { color: '#666', maxTicksLimit: 20, maxRotation: 45 },
-								grid: { color: '#1e1e1e' },
-							},
-							y: {
-								ticks: { color: '#666' },
-								grid: { color: '#1e1e1e' },
-							},
-						},
 					},
-				});
-			}
+					scales: {
+						x: { ticks: { color: '#888', maxTicksLimit: 20, maxRotation: 45 }, grid: { color: '#ececec' } },
+						y: { ticks: { color: '#888' }, grid: { color: '#ececec' } },
+					},
+				},
+			});
+		}
 
-			load();
+		load();
 		</script>
 	</body>
 </html>

--- a/src/integrations/telegram/messages/BidTaken.message.ts
+++ b/src/integrations/telegram/messages/BidTaken.message.ts
@@ -1,30 +1,23 @@
 import { BidsQueryItem, ChallengesQueryItem } from 'modules/challenges/challenges.types';
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
 export function BidTakenMessage(position: PositionQuery, challenge: ChallengesQueryItem, bid: BidsQueryItem): string {
-	return `
-*New Bid Taken*
+	return `💸 *Bid Taken*
 
-Position: ${bid.position} (v${position.version})
-Bidder: ${bid.bidder}
-Challenge Index: ${bid.number}
-Bid Index: ${bid.numberBid}
-Bid Type: *${bid.bidType}*
+🏦 Position: \`${shortenString(bid.position)}\` (v${position.version})
+👤 Bidder: \`${shortenString(bid.bidder)}\`
+📋 Challenge: #${bid.number} · Bid: #${bid.numberBid}
+🏷 Type: *${bid.bidType}*
 
-Collateral: ${position.collateralName} (${position.collateralSymbol})
-Challenge Size: ${formatCurrency(formatUnits(bid.challengeSize, position.collateralDecimals))} ${position.collateralSymbol}
+💎 Collateral: *${position.collateralName} (${position.collateralSymbol})*
+   Challenge Size: *${formatCurrency(formatUnits(bid.challengeSize, position.collateralDecimals))} ${position.collateralSymbol}*
+   Bid Filled: *${formatCurrency(formatUnits(bid.filledSize, position.collateralDecimals))} ${position.collateralSymbol}*
+   Bid Amount: *${formatCurrency(formatUnits(bid.bid, 18))} ZCHF*
+   Bid Price: *${formatCurrency(formatUnits(bid.price, 36 - position.collateralDecimals))} ZCHF/${position.collateralSymbol}*
 
-Bid Amount: ${formatCurrency(formatUnits(bid.bid, 18))} ZCHF
-Bid Filled: ${formatCurrency(formatUnits(bid.filledSize, position.collateralDecimals))} ${position.collateralSymbol}
-Bid Price: ${formatCurrency(formatUnits(bid.price, 36 - position.collateralDecimals))} ZCHF/${position.collateralSymbol}
-
-[Buy ${position.collateralSymbol} in Auction](${AppUrl(`/monitoring/${bid.position}/auction/${bid.number}`)})
-[Goto Position](${AppUrl(`/monitoring/${bid.position}`)})
-
-[Explorer Bidder](${ExplorerAddressUrl(bid.bidder)}) 
-[Explorer Position](${ExplorerAddressUrl(bid.position)})
-                        `;
+[💸 Buy in Auction](${AppUrl(`/monitoring/${bid.position}/auction/${bid.number}`)}) · [📋 Position](${AppUrl(`/monitoring/${bid.position}`)})
+[🔍 Bidder](${ExplorerAddressUrl(bid.bidder)}) · [🔍 Position](${ExplorerAddressUrl(bid.position)})`;
 }

--- a/src/integrations/telegram/messages/ChallengeStarted.message.ts
+++ b/src/integrations/telegram/messages/ChallengeStarted.message.ts
@@ -1,48 +1,38 @@
 import { ChallengesQueryItem } from 'modules/challenges/challenges.types';
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
 export function ChallengeStartedMessage(position: PositionQuery, challenge: ChallengesQueryItem): string {
-	const size: number = parseInt(formatUnits(BigInt(challenge.size), position.collateralDecimals - 2)) / 100;
-	const min: number = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
-	const price: number = parseInt(formatUnits(BigInt(challenge.liqPrice), 36 - position.collateralDecimals - 2)) / 100;
-	const duration: number = parseInt(challenge.duration.toString()) * 1000;
+	const size = parseInt(formatUnits(BigInt(challenge.size), position.collateralDecimals - 2)) / 100;
+	const min = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
+	const price = parseInt(formatUnits(BigInt(challenge.liqPrice), 36 - position.collateralDecimals - 2)) / 100;
+	const duration = parseInt(challenge.duration.toString()) * 1000;
 
-	const startChallenge: number = parseInt(challenge.start.toString()) * 1000;
-	const expirationChallengeVirtual: number = startChallenge + 2 * duration;
-	const expirationPosition: number = position.expiration * 1000;
-	const isQuickAuction: boolean = expirationChallengeVirtual > expirationPosition;
-	const expirationChallenge: number = Math.min(expirationChallengeVirtual, expirationPosition);
-	const expirationPhase1: number | undefined = isQuickAuction ? undefined : startChallenge + duration;
+	const startMs = parseInt(challenge.start.toString()) * 1000;
+	const expirationVirtual = startMs + 2 * duration;
+	const expirationPosition = position.expiration * 1000;
+	const isQuickAuction = expirationVirtual > expirationPosition;
+	const expirationFinal = Math.min(expirationVirtual, expirationPosition);
+	const phase1End = isQuickAuction ? undefined : startMs + duration;
 
-	return `
-*New Challenge Started*
+	return `⚔️ *Challenge Started*
 
-Number: ${challenge.number}
-Challenger: ${challenge.challenger}
-Position: ${position.position} (v${position.version})
-Owner: ${position.owner}
+#${challenge.number} on \`${shortenString(position.position)}\` (v${position.version})
+⚡ Quick Auction: *${isQuickAuction ? 'Yes' : 'No'}*
 
-Collateral: ${position.collateralName} (${position.collateralSymbol})
-At: ${position.collateral}
-Size: ${formatCurrency(size, 2, 2)} ${position.collateralSymbol}
-Min: ${formatCurrency(min, 2, 2)} ${position.collateralSymbol}
-Starting Price: ${formatCurrency(price, 2, 2)} ZCHF
+⚔️ Challenger: \`${shortenString(challenge.challenger)}\`
+👤 Owner: \`${shortenString(position.owner)}\`
 
-Duration: ${formatCurrency(duration / 1000 / 60 / 60, 1, 1)} hours
-Quick Auction: ${isQuickAuction}
-Begin: ${new Date(startChallenge).toString().split(' ').slice(0, 5).join(' ')}
-Phase1 End: ${new Date(expirationPhase1).toString().split(' ').slice(0, 5).join(' ')}
-Phase2 End: ${new Date(expirationChallenge).toString().split(' ').slice(0, 5).join(' ')}
+💎 Collateral: *${position.collateralName} (${position.collateralSymbol})*
+   Size: *${formatCurrency(size, 2, 2)} ${position.collateralSymbol}* (min *${formatCurrency(min, 2, 2)}*)
+   Starting Price: *${formatCurrency(price, 2, 2)} ZCHF*
+   Duration: *${formatCurrency(duration / 1000 / 3600, 1, 1)} hours*
 
-[Buy ${position.collateralSymbol} in Auction](${AppUrl(`/monitoring/${position.position}/auction/${challenge.number}`)})
-[Goto Position](${AppUrl(`/monitoring/${position.position}`)})
+📅 Phase 1 End: *${phase1End ? new Date(phase1End).toUTCString() : 'N/A (quick auction)'}*
+📅 Phase 2 End: *${new Date(expirationFinal).toUTCString()}*
 
-[Explorer Challenger](${ExplorerAddressUrl(challenge.challenger)}) 
-[Explorer Position](${ExplorerAddressUrl(position.position)})
-[Explorer Owner](${ExplorerAddressUrl(position.owner)}) 
-[Explorer Collateral](${ExplorerAddressUrl(position.collateral)}) 
-                        `;
+[💸 Buy in Auction](${AppUrl(`/monitoring/${position.position}/auction/${challenge.number}`)}) · [📋 Position](${AppUrl(`/monitoring/${position.position}`)})
+[🔍 Challenger](${ExplorerAddressUrl(challenge.challenger)}) · [🔍 Position](${ExplorerAddressUrl(position.position)})`;
 }

--- a/src/integrations/telegram/messages/DailyInfos.message.ts
+++ b/src/integrations/telegram/messages/DailyInfos.message.ts
@@ -4,37 +4,31 @@ import { formatCurrency } from 'utils/format';
 import { formatUnits } from 'viem';
 
 export function DailyInfosMessage(before: AnalyticsDailyLog, now: AnalyticsDailyLog, supply: FrankencoinSupplyQueryObject): string {
-	// overwrite total supply with multichain supply
-	const timestampBefore = new Date(before.date).getTime();
-	const timestampAfter = new Date(now.date).getTime();
+	const tsAfter = new Date(now.date).getTime();
+	const tsBefore = new Date(before.date).getTime();
 
 	const keys = Object.keys(supply).map((i) => parseInt(i) * 1000);
 
-	const filteredBefore = keys.filter((i) => i <= timestampBefore);
-	const keyBefore = filteredBefore.at(-1);
+	const keyBefore = keys.filter((i) => i <= tsBefore).at(-1);
 	const supplyBefore = supply[keyBefore / 1000].supply;
 
-	const filteredAfter = keys.filter((i) => i <= timestampAfter);
-	const keyAfter = filteredAfter.at(-1);
+	const keyAfter = keys.filter((i) => i <= tsAfter).at(-1);
 	const supplyAfter = supply[keyAfter / 1000].supply;
 
-	// Total Supply, changes
-	const totalSupplyChangePct = (supplyAfter / supplyBefore - 1) * 100;
+	const supplyChangePct = (supplyAfter / supplyBefore - 1) * 100;
 	const fpsPriceChangePct = (BigInt(now.fpsPrice) * 10n ** 20n) / BigInt(before.fpsPrice) - 10n ** 20n;
 
 	const inSavingsPct = (BigInt(now.totalSavings) * 10n ** 20n) / BigInt(now.totalSupply);
 	const inEquityPct = (BigInt(now.totalEquity) * 10n ** 20n) / BigInt(now.totalSupply);
 
-	return `
-*Frankencoin Infos*
+	return `📊 *Frankencoin Weekly Snapshot*
 
-Total Supply: ${formatCurrency(supplyAfter, 0, 0)} ZCHF 
-Last 30d: ${formatCurrency(totalSupplyChangePct)}%
+💵 Total Supply: *${formatCurrency(supplyAfter, 0, 0)} ZCHF*
+   Last 30d: *${formatCurrency(supplyChangePct)}%*
 
-In Equity: ${formatCurrency(formatUnits(inEquityPct, 18))}%
-In Savings: ${formatCurrency(formatUnits(inSavingsPct, 18))}%
+🔒 In Equity: *${formatCurrency(formatUnits(inEquityPct, 18))}%*
+💰 In Savings: *${formatCurrency(formatUnits(inSavingsPct, 18))}%*
 
-FPS Price: ${formatCurrency(formatUnits(now.fpsPrice, 18), 0, 0)} ZCHF 
-Last 30d: ${formatCurrency(formatUnits(fpsPriceChangePct, 18))}%
-`;
+📈 FPS Price: *${formatCurrency(formatUnits(now.fpsPrice, 18), 0, 0)} ZCHF*
+   Last 30d: *${formatCurrency(formatUnits(fpsPriceChangePct, 18))}%*`;
 }

--- a/src/integrations/telegram/messages/EquityInvested.message.ts
+++ b/src/integrations/telegram/messages/EquityInvested.message.ts
@@ -7,16 +7,13 @@ export function EquityInvestedMessage(log: AnalyticsTransactionLog): string {
 	const d = new Date(Number(log.timestamp) * 1000);
 	const cap = BigInt(log.fpsPrice) * BigInt(log.fpsTotalSupply);
 
-	return `
-*Equity Invested*
+	return `💰 *Equity Invested*
 
-Date: ${d.toString().split(' ').slice(0, 5).join(' ')}
 *Amount: ${formatCurrency(formatUnits(log.amount, 18))} ZCHF*
+📅 Date: *${d.toUTCString()}*
 
-Current Price: ${formatCurrency(formatUnits(log.fpsPrice, 18))} ZCHF
-Current Market Cap.: ${formatCurrency(formatUnits(cap, 18 * 2))} ZCHF
+FPS Price: *${formatCurrency(formatUnits(log.fpsPrice, 18))} ZCHF*
+Market Cap: *${formatCurrency(formatUnits(cap, 36))} ZCHF*
 
-[Goto Governance](${AppUrl(`/equity`)})
-[Explorer Transaction](${ExplorerTxUrl(log.txHash)})
-`;
+[🏦 Equity](${AppUrl('/equity')}) · [🔍 Explorer](${ExplorerTxUrl(log.txHash)})`;
 }

--- a/src/integrations/telegram/messages/EquityRedeemed.message.ts
+++ b/src/integrations/telegram/messages/EquityRedeemed.message.ts
@@ -7,16 +7,13 @@ export function EquityRedeemedMessage(log: AnalyticsTransactionLog): string {
 	const d = new Date(Number(log.timestamp) * 1000);
 	const cap = BigInt(log.fpsPrice) * BigInt(log.fpsTotalSupply);
 
-	return `
-*Equity Redeemed*
+	return `💸 *Equity Redeemed*
 
-Date: ${d.toString().split(' ').slice(0, 5).join(' ')}
 *Amount: ${formatCurrency(formatUnits(log.amount, 18))} ZCHF*
+📅 Date: *${d.toUTCString()}*
 
-Current Price: ${formatCurrency(formatUnits(log.fpsPrice, 18))} ZCHF
-Current Market Cap.: ${formatCurrency(formatUnits(cap, 18 * 2))} ZCHF
+FPS Price: *${formatCurrency(formatUnits(log.fpsPrice, 18))} ZCHF*
+Market Cap: *${formatCurrency(formatUnits(cap, 36))} ZCHF*
 
-[Goto Governance](${AppUrl(`/equity`)})
-[Explorer Transaction](${ExplorerTxUrl(log.txHash)})
-`;
+[🏦 Equity](${AppUrl('/equity')}) · [🔍 Explorer](${ExplorerTxUrl(log.txHash)})`;
 }

--- a/src/integrations/telegram/messages/Help.message.ts
+++ b/src/integrations/telegram/messages/Help.message.ts
@@ -1,26 +1,31 @@
 import { AppUrl } from 'utils/func-helper';
 import { mainnet } from 'viem/chains';
 
+const HANDLE_LABELS: Record<string, string> = {
+	'/MintingUpdates': '📊 Minting Updates',
+	'/PriceAlerts': '⚠️ Price Alerts',
+	'/DailyInfos': '📅 Daily Infos (weekly)',
+};
+
 export function HelpMessage(handles: string[], chatSubs: { [handle: string]: boolean }): string {
-	const subTo = handles.filter((h) => chatSubs[h.replace('/', '')]);
+	const subscriptionLines = handles
+		.filter((h) => h !== '/help')
+		.map((h) => {
+			const key = h.replace('/', '');
+			const label = HANDLE_LABELS[h] ?? h;
+			const status = chatSubs[key] ? '✅' : '⬜';
+			return `${status} ${label}`;
+		})
+		.join('\n');
 
-	return `
-*Hello again, from the Frankencoin API Bot!*
+	return `ℹ️ *Frankencoin Bot*
 
-I am listening to changes within the Frankencoin ecosystem.
+Monitoring the Frankencoin ecosystem on ${mainnet.name} (chain ${mainnet.id}).
 
-*Available subscription handles*
-${handles.join('\n')}
+📡 *Subscriptions*
+${subscriptionLines}
 
-*Subscripted to*
-${subTo.length > 0 ? subTo.join('\n') : 'Not subscripted to any handles.'}
+Use /subscribe to toggle alert types.
 
-*Environment*
-Api Version: ${process.env.npm_package_version}
-Chain/Network: ${mainnet.name} (${mainnet.id})
-Time: ${new Date().toString().split(' ').slice(0, 5).join(' ')}
-
-[Goto App](${AppUrl('')})
-[Github Api](https://github.com/Frankencoin-ZCHF/frankencoin-api)
-`;
+v${process.env.npm_package_version} · [🌐 App](${AppUrl('')})`;
 }

--- a/src/integrations/telegram/messages/LeadrateChanged.message.ts
+++ b/src/integrations/telegram/messages/LeadrateChanged.message.ts
@@ -5,13 +5,10 @@ import { AppUrl, ExplorerTxUrl } from 'utils/func-helper';
 export function LeadrateChangedMessage(rate: LeadrateRateQuery): string {
 	const d = new Date(rate.created * 1000);
 
-	return `
-*Leadrate Changed*
+	return `✅ *Savings Rate Updated*
 
-Valid from: ${d.toString().split(' ').slice(0, 5).join(' ')}
-Approved Rate: ${formatCurrency(rate.approvedRate / 10_000)}%
+📈 New Rate: *${formatCurrency(rate.approvedRate / 10_000)}%*
+📅 Valid From: *${d.toUTCString()}*
 
-[Goto Governance](${AppUrl(`/governance`)})
-[Explorer Transaction](${ExplorerTxUrl(rate.txHash)})
-                        `;
+[🏛️ Governance](${AppUrl('/governance')}) · [🔍 Explorer](${ExplorerTxUrl(rate.txHash)})`;
 }

--- a/src/integrations/telegram/messages/LeadrateProposal.message.ts
+++ b/src/integrations/telegram/messages/LeadrateProposal.message.ts
@@ -1,25 +1,21 @@
 import { LeadrateProposedQuery, LeadrateRateQuery } from 'modules/savings/savings.leadrate.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerTxUrl } from 'utils/func-helper';
 
 export function LeadrateProposalMessage(proposal: LeadrateProposedQuery, rates: LeadrateRateQuery[]): string {
-	const d = new Date(proposal.nextChange * 1000);
-	const r = rates.find((r) => r.module === proposal.module)?.approvedRate;
-	const u = r === proposal.nextRate;
+	const deadline = new Date(proposal.nextChange * 1000);
+	const currentRate = rates.find((r) => r.module === proposal.module)?.approvedRate;
+	const isUnchanged = currentRate === proposal.nextRate;
 
-	return `
-*New Leadrate Proposal*
+	return `📊 *New Leadrate Proposal*
 
-Proposal Period: 7 days
-Proposal Until: ${d.toString().split(' ').slice(0, 5).join(' ')}
-Proposer: ${proposal.proposer}
+📅 Valid Until: *${deadline.toUTCString()}*
+👤 Proposer: \`${shortenString(proposal.proposer)}\`
 
-Current Rate: ${formatCurrency(r / 10000)}%
-Proposed Rate: ${formatCurrency(proposal.nextRate / 10000)}%
+📈 Current Rate: *${formatCurrency(currentRate / 10000)}%*
+📈 Proposed Rate: *${formatCurrency(proposal.nextRate / 10000)}%*
 
-${u ? '*Rate will remain unchanged*' : '*Rate can be applied after 7 days*'}
+${isUnchanged ? '*Rate will remain unchanged*' : '*Rate can be applied after 7 days*'}
 
-[Goto Governance](${AppUrl(`/governance`)})
-[Explorer Transaction](${ExplorerTxUrl(proposal.txHash)})
-                        `;
+[🏛️ Governance](${AppUrl('/governance')}) · [🔍 Explorer](${ExplorerTxUrl(proposal.txHash)})`;
 }

--- a/src/integrations/telegram/messages/MinterProposal.message.ts
+++ b/src/integrations/telegram/messages/MinterProposal.message.ts
@@ -1,22 +1,20 @@
 import { MinterQuery } from 'modules/ecosystem/ecosystem.minter.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerTxUrl, getChain } from 'utils/func-helper';
 import { Chain } from 'viem';
 
 export function MinterProposalMessage(minter: MinterQuery): string {
-	const d = new Date((minter.applyDate + minter.applicationPeriod) * 1000);
+	const vetoDeadline = new Date((minter.applyDate + minter.applicationPeriod) * 1000);
+	const hours = Math.floor(minter.applicationPeriod / 3600);
 
-	return `
-*New Minter Proposal*
+	return `🏛️ *New Minter Proposal*
 
-Application Period: ${Math.floor(minter.applicationPeriod / 60 / 60)} hours
-Application Veto Until: ${d.toString().split(' ').slice(0, 5).join(' ')}
-Minter: ${minter.minter}
-Suggestor: ${minter.suggestor}
-Application Fee: ${formatCurrency(minter.applicationFee / 1e18, 2, 2)} ZCHF
-Message: ${minter.applyMessage}
+👤 Minter: \`${shortenString(minter.minter)}\`
+👤 Suggestor: \`${shortenString(minter.suggestor)}\`
+💰 Fee: *${formatCurrency(minter.applicationFee / 1e18, 2, 2)} ZCHF*
+⏱ Period: *${hours} hours*
+⏰ Veto Until: *${vetoDeadline.toUTCString()}*
+💬 Message: ${minter.applyMessage || '—'}
 
-[Goto Governance](${AppUrl(`/governance`)})
-[Explorer Transaction](${ExplorerTxUrl(minter.txHash, getChain(minter.chainId) as Chain)})
-                        `;
+[🏛️ Governance](${AppUrl('/governance')}) · [🔍 Explorer](${ExplorerTxUrl(minter.txHash, getChain(minter.chainId) as Chain)})`;
 }

--- a/src/integrations/telegram/messages/MinterProposalVetoed.message.ts
+++ b/src/integrations/telegram/messages/MinterProposalVetoed.message.ts
@@ -1,21 +1,18 @@
 import { MinterQuery } from 'modules/ecosystem/ecosystem.minter.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerTxUrl, getChain } from 'utils/func-helper';
 import { Chain } from 'viem';
 
 export function MinterProposalVetoedMessage(minter: MinterQuery): string {
-	return `
-*Minter Proposal Vetoed*
+	return `🚫 *Minter Proposal Vetoed*
 
-Minter: ${minter.minter}
-Suggestor: ${minter.suggestor}
-Application Fee: ${formatCurrency(minter.applicationFee / 1e18, 2, 2)} ZCHF
-Message: ${minter.applyMessage}
+👤 Minter: \`${shortenString(minter.minter)}\`
+👤 Suggestor: \`${shortenString(minter.suggestor)}\`
+💰 Fee: *${formatCurrency(minter.applicationFee / 1e18, 2, 2)} ZCHF*
+💬 Apply: ${minter.applyMessage || '—'}
 
-Vetor: ${minter.vetor}
-Message: ${minter.denyMessage}
+🚫 Vetor: \`${shortenString(minter.vetor)}\`
+💬 Reason: ${minter.denyMessage || '—'}
 
-[Goto Governance](${AppUrl(`/governance`)})
-[Explorer Transaction](${ExplorerTxUrl(minter.denyTxHash, getChain(minter.chainId) as Chain)})
-`;
+[🏛️ Governance](${AppUrl('/governance')}) · [🔍 Explorer](${ExplorerTxUrl(minter.denyTxHash, getChain(minter.chainId) as Chain)})`;
 }

--- a/src/integrations/telegram/messages/MintingUpdate.message.ts
+++ b/src/integrations/telegram/messages/MintingUpdate.message.ts
@@ -1,50 +1,39 @@
 import { MintingUpdateQuery } from 'modules/positions/positions.types';
 import { PriceQuery, PriceQueryObjectArray } from 'modules/prices/prices.types';
-import { formatCurrency, normalizeAddress } from 'utils/format';
+import { formatCurrency, normalizeAddress, shortenString } from 'utils/format';
 import { formatUnits } from 'viem';
 import { AppUrl, ExplorerAddressUrl, ExplorerTxUrl } from 'utils/func-helper';
 
 export function MintingUpdateMessage(minting: MintingUpdateQuery, prices: PriceQueryObjectArray): string {
 	const marketPrice = (prices[normalizeAddress(minting.collateral)] as PriceQuery).price?.chf || 1;
-
 	const liqPrice = parseFloat(formatUnits(BigInt(minting.price), 36 - minting.collateralDecimals));
-	// const liqPriceAdjusted = parseFloat(formatUnits(BigInt(minting.priceAdjusted), 36 - minting.collateralDecimals));
-
 	const ratio = marketPrice / liqPrice;
-	// const ratioAdjusted = marketPrice / liqPriceAdjusted;
-
 	const minted = parseFloat(formatUnits(BigInt(minting.minted), 18));
 	const mintedAdjusted = parseFloat(formatUnits(BigInt(minting.mintedAdjusted), 18));
+	const timeframeDays = Math.round(minting.feeTimeframe / 86400);
+	const sign = mintedAdjusted >= 0 ? '+' : '-';
 
-	const timefram = Math.round(minting.feeTimeframe / 60 / 60 / 24);
+	return `🔄 *New Minting*
 
-	const absStr = (n: number) => (n >= 0 ? '+' : '-');
+🏦 Position: \`${shortenString(minting.position)}\` (v${minting.version})
+👤 Owner: \`${shortenString(minting.owner)}\`
 
-	return `
-*New Minting Update*
+💎 Collateral: *${minting.collateralName} (${minting.collateralSymbol})*
+   Market Price: *${formatCurrency(marketPrice, 2)} ZCHF*
+   Liq. Price: *${formatCurrency(liqPrice, 2)} ZCHF*
+   *Ratio: ${formatCurrency(ratio * 100, 2)}%*
 
-Position: ${minting.position} (v${minting.version})
-Owner: ${minting.owner}
-[App Position](${AppUrl(`/monitoring/${minting.position}`)})
+💵 Minted: *${formatCurrency(minted, 2)} ZCHF*
+   *Change: ${sign}${formatCurrency(Math.abs(mintedAdjusted), 2)} ZCHF*
 
-Collateral: ${minting.collateralName} (${minting.collateralSymbol})
-Market Price: ${formatCurrency(marketPrice, 2)} ZCHF
-Liq. Price: ${formatCurrency(liqPrice, 2)} ZCHF
-*Ratio: ${formatCurrency(ratio * 100, 2)}%*
+📊 Rates
+   Interest: *${formatCurrency(minting.annualInterestPPM / 10000, 2)}%* APY
+   Reserve: *${formatCurrency(minting.reserveContribution / 10000, 2)}%*
 
-Minted: ${formatCurrency(minted, 2)} ZCHF
-*Changed: ${absStr(mintedAdjusted)}${formatCurrency(mintedAdjusted, 2)} ZCHF*
+📊 Fee
+   Timeframe: *${timeframeDays} days*
+   Rate: *${formatCurrency(minting.feePPM / 10000, 2)}%*
+   *Paid: ${formatCurrency(formatUnits(BigInt(minting.feePaid), 18), 2)} ZCHF*
 
-Annual Interest: ${formatCurrency(minting.annualInterestPPM / 10000, 2)}%
-Reserve: ${formatCurrency(minting.reserveContribution / 10000, 2)}%
-
-FeeTimeframe: ${timefram} days
-FeePct: ${formatCurrency(minting.feePPM / 10000, 2)}%
-*FeePaid: ${formatCurrency(formatUnits(BigInt(minting.feePaid), 18), 2)} ZCHF*
-
-[Explorer Position](${ExplorerAddressUrl(minting.position)})
-[Explorer Owner](${ExplorerAddressUrl(minting.owner)})
-[Explorer Collateral](${ExplorerAddressUrl(minting.collateral)})
-[Explorer Transaction](${ExplorerTxUrl(minting.txHash)})
-`;
+[🔍 Position](${ExplorerAddressUrl(minting.position)}) · [🔍 Owner](${ExplorerAddressUrl(minting.owner)}) · [🔍 Tx](${ExplorerTxUrl(minting.txHash)})`;
 }

--- a/src/integrations/telegram/messages/PositionDenied.message.ts
+++ b/src/integrations/telegram/messages/PositionDenied.message.ts
@@ -1,29 +1,26 @@
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
 export function PositionDeniedMessage(position: PositionQuery): string {
 	const bal = formatUnits(BigInt(position.collateralBalance), position.collateralDecimals);
 	const price = formatUnits(BigInt(position.price), 36 - position.collateralDecimals);
-	const deniedDate = position.denyDate > 0 ? new Date(position.denyDate * 1000).toString().split(' ').splice(0, 5).join(' ') : 'Unknown';
+	const denied = position.denyDate > 0 ? new Date(position.denyDate * 1000).toUTCString() : 'Unknown';
 
-	return `
-*Position Denied by Governance*
+	return `🚫 *Position Denied*
 
-Denied: ${deniedDate}
-Position: ${position.position}
-Owner: ${position.owner}
-Minting Limit: ${formatCurrency(formatUnits(BigInt(position.version === 1 ? position.limitForClones : (position as any).limitForClones), 18), 2, 2)} ZCHF
-Annual Interest: ${formatCurrency(position.annualInterestPPM / 10000, 1, 1)}%
+📅 Denied: *${denied}*
+🏦 Position: \`${shortenString(position.position)}\`
+👤 Owner: \`${shortenString(position.owner)}\`
 
-Collateral: ${position.collateralName} (${position.collateralSymbol})
-At: ${position.collateral}
-Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
-Price: ${formatCurrency(price, 2, 2)} ZCHF
+💎 Collateral: *${position.collateralName} (${position.collateralSymbol})*
+   Address: \`${shortenString(position.collateral)}\`
+   Balance: *${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}*
+   Liq. Price: *${formatCurrency(price, 2, 2)} ZCHF*
 
-[Explorer Position](${ExplorerAddressUrl(position.position)})
-[Explorer Owner](${ExplorerAddressUrl(position.owner)})
-[Explorer Collateral](${ExplorerAddressUrl(position.collateral)})
-                        `;
+📊 Limit: *${formatCurrency(formatUnits(BigInt(position.limitForClones), 18), 2, 2)} ZCHF*
+   Interest: *${formatCurrency(position.annualInterestPPM / 10000, 1, 1)}%* APY
+
+[🔍 Position](${ExplorerAddressUrl(position.position)}) · [🔍 Owner](${ExplorerAddressUrl(position.owner)}) · [🔍 Collateral](${ExplorerAddressUrl(position.collateral)})`;
 }

--- a/src/integrations/telegram/messages/PositionExpired.message.ts
+++ b/src/integrations/telegram/messages/PositionExpired.message.ts
@@ -1,66 +1,48 @@
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
 export function PositionExpiredMessage(position: PositionQuery): string {
-	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
-	const min: number = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
-	const price: number = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
-	const duration: number = position.challengePeriod * 1000;
+	const bal = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
+	const min = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
+	const price = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
+	const duration = position.challengePeriod * 1000;
 
-	const begin = new Date(position.expiration * 1000);
-	const mid = new Date(position.expiration * 1000 + 1 * duration);
-	const zero = new Date(position.expiration * 1000 + 2 * duration);
+	const t0 = new Date(position.expiration * 1000);
+	const t1 = new Date(position.expiration * 1000 + duration);
+	const t2 = new Date(position.expiration * 1000 + 2 * duration);
 
-	const header = `
-*Position is expired*
+	const header = `💀 *Position Expired*
 
-Position: ${position.position} (v${position.version})
-Owner: ${position.owner}
+🏦 Position: \`${shortenString(position.position)}\` (v${position.version})
+👤 Owner: \`${shortenString(position.owner)}\`
 
-Minted: ${formatCurrency(formatUnits(BigInt(position.minted), 18), 2, 2)} ZCHF
-Retained Reserve: ${formatCurrency(position.reserveContribution / 10000, 1, 1)}%
-Auction Duration: ${Math.floor(position.challengePeriod / 60 / 60)} hours
+💎 Collateral: *${position.collateralName} (${position.collateralSymbol})*
+   Address: \`${shortenString(position.collateral)}\`
+   Balance: *${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}* (min *${formatCurrency(min, 2, 2)}*)
 
-Collateral: ${position.collateralName} (${position.collateralSymbol})
-At: ${position.collateral}
-Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
-Bal. min.: ${formatCurrency(min, 2, 2)} ${position.collateralSymbol}
-`;
+💵 Minted: *${formatCurrency(formatUnits(BigInt(position.minted), 18), 2, 2)} ZCHF*
+   Reserve: *${formatCurrency(position.reserveContribution / 10000, 1, 1)}%* · Auction: *${Math.floor(position.challengePeriod / 3600)} hours*`;
 
 	const v1Body = `
-*Challenge is available*
 
-Declines (1x -> 0x Price): ${begin.toUTCString()}
-Price (1x): ${formatCurrency(price, 2, 2)} ZCHF per 1 ${position.collateralSymbol}
-
-Zero: ${mid.toUTCString()}
-Price (0x): 0.00 ZCHF per 1 ${position.collateralSymbol}
-`;
+⚔️ *Challenge Available*
+   1x → 0x from: *${t0.toUTCString()}*
+   Price (1x): *${formatCurrency(price, 2, 2)} ZCHF/${position.collateralSymbol}*
+   Zero at: *${t1.toUTCString()}*`;
 
 	const v2Body = `
-*ForceSell is available*
 
-Declines (10x -> 1x Price): ${begin.toUTCString()}
-Price (10x): ${formatCurrency(price * 10, 2, 2)} ZCHF per 1 ${position.collateralSymbol}
-
-Continues (1x -> 0x Price): ${mid.toUTCString()}
-Price (1x): ${formatCurrency(price, 2, 2)} ZCHF per 1 ${position.collateralSymbol}
-
-Zero: ${zero.toUTCString()}
-Price (0x): 0.00 ZCHF per 1 ${position.collateralSymbol}
-`;
+⚡ *ForceSell Available*
+   10x → 1x from: *${t0.toUTCString()}* (Price: *${formatCurrency(price * 10, 2, 2)} ZCHF*)
+   1x → 0x from: *${t1.toUTCString()}* (Price: *${formatCurrency(price, 2, 2)} ZCHF*)
+   Zero at: *${t2.toUTCString()}*`;
 
 	const footer = `
 
-[Overview Position](${AppUrl(`/monitoring/${position.position}`)})
-[Buy Collateral](${AppUrl(`/monitoring/${position.position}/${position.version == 1 ? 'challenge' : 'forceSell'}`)})
+[📋 Overview](${AppUrl(`/monitoring/${position.position}`)}) · [💸 Buy Collateral](${AppUrl(`/monitoring/${position.position}/${position.version == 1 ? 'challenge' : 'forceSell'}`)})
+[🔍 Position](${ExplorerAddressUrl(position.position)}) · [🔍 Owner](${ExplorerAddressUrl(position.owner)})`;
 
-[Explorer Position](${ExplorerAddressUrl(position.position)})
-[Explorer Owner](${ExplorerAddressUrl(position.owner)}) 
-[Explorer Collateral](${ExplorerAddressUrl(position.collateral)}) 
-`;
-
-	return position.version == 1 ? header + v1Body + footer : header + v2Body + footer;
+	return header + (position.version == 1 ? v1Body : v2Body) + footer;
 }

--- a/src/integrations/telegram/messages/PositionExpiringSoon.message.ts
+++ b/src/integrations/telegram/messages/PositionExpiringSoon.message.ts
@@ -1,36 +1,32 @@
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
 export function PositionExpiringSoonMessage(position: PositionQuery): string {
-	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
-	const min: number = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
-	const price: number = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
-	const date = new Date(position.expiration * 1000);
+	const bal = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
+	const min = parseInt(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals - 2)) / 100;
+	const price = parseInt(formatUnits(BigInt(position.price), 36 - position.collateralDecimals - 2)) / 100;
+	const expiryDate = new Date(position.expiration * 1000);
+	const expiryDays = formatCurrency((position.expiration * 1000 - Date.now()) / 1000 / 60 / 60 / 24);
+	const auctionHours = Math.floor(position.challengePeriod / 3600);
 
-	return `
-*Position will expire soon*
+	return `⏰ *Position Expiring Soon*
 
-Position: ${position.position} (v${position.version})
-Owner: ${position.owner}
+🏦 Position: \`${shortenString(position.position)}\` (v${position.version})
+👤 Owner: \`${shortenString(position.owner)}\`
 
-Minted: ${formatCurrency(formatUnits(BigInt(position.minted), 18), 2, 2)} ZCHF
-Retained Reserve: ${formatCurrency(position.reserveContribution / 10000, 1, 1)}%
-Auction Duration: ${Math.floor(position.challengePeriod / 60 / 60)} hours
-Expiration: ${formatCurrency((position.expiration * 1000 - Date.now()) / 1000 / 60 / 60 / 24)} days
-At: ${date.toUTCString()}
+📅 Expiry: *${expiryDate.toUTCString()}* (in *${expiryDays} days*)
+⏱ Auction Duration: *${auctionHours} hours*
 
-Collateral: ${position.collateralName} (${position.collateralSymbol})
-At: ${position.collateral}
-Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
-Bal. min.: ${formatCurrency(min, 2, 2)} ${position.collateralSymbol}
-Price: ${formatCurrency(price, 2, 2)} ZCHF
+💎 Collateral: *${position.collateralName} (${position.collateralSymbol})*
+   Address: \`${shortenString(position.collateral)}\`
+   Balance: *${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}* (min *${formatCurrency(min, 2, 2)}*)
+   Liq. Price: *${formatCurrency(price, 2, 2)} ZCHF*
 
-[Overview Position](${AppUrl(`/monitoring/${position.position}`)})
+💵 Minted: *${formatCurrency(formatUnits(BigInt(position.minted), 18), 2, 2)} ZCHF*
+   Reserve: *${formatCurrency(position.reserveContribution / 10000, 1, 1)}%*
 
-[Explorer Position](${ExplorerAddressUrl(position.position)})
-[Explorer Owner](${ExplorerAddressUrl(position.owner)}) 
-[Explorer Collateral](${ExplorerAddressUrl(position.collateral)}) 
-                        `;
+[📋 Overview](${AppUrl(`/monitoring/${position.position}`)})
+[🔍 Position](${ExplorerAddressUrl(position.position)}) · [🔍 Owner](${ExplorerAddressUrl(position.owner)})`;
 }

--- a/src/integrations/telegram/messages/PositionPrice.message.ts
+++ b/src/integrations/telegram/messages/PositionPrice.message.ts
@@ -1,72 +1,54 @@
 import { PriceQuery } from 'modules/prices/prices.types';
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, shortenString } from 'utils/format';
 import { AppUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 import { PositionPriceAlertState } from 'integrations/telegram/telegram.types';
 
-export function PositionPriceLowest(position: PositionQuery, price: PriceQuery, last: PositionPriceAlertState): string {
-	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
+function priceBody(position: PositionQuery, price: PriceQuery): string {
+	const bal = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
 	const posPrice = parseFloat(formatUnits(BigInt(position.price), 36 - position.collateralDecimals));
+	const ratio = Math.round((price.price.chf / posPrice) * 10000) / 100;
 
-	return `
-*Position Price Declines*
+	return `🏦 Position: \`${shortenString(position.position)}\`
+💎 *${position.collateralName} (${position.collateralSymbol})* — *${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}*
 
-Position: ${position.position}
-Collateral: ${position.collateralName} (${position.collateralSymbol})
-Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
+   Liq. Price: *${formatCurrency(posPrice, 2, 2)} ZCHF*
+   Market Price: *${formatCurrency(price.price.chf, 2, 2)} ZCHF*`;
+}
 
-Position Price: ${posPrice} ZCHF
-CoinGecko Price: ${price.price.chf} ZCHF
-Collateralization: ${Math.round((price.price.chf / posPrice) * 10000) / 100}%
+export function PositionPriceLowest(position: PositionQuery, price: PriceQuery, last: PositionPriceAlertState): string {
+	const posPrice = parseFloat(formatUnits(BigInt(position.price), 36 - position.collateralDecimals));
+	const ratio = Math.round((price.price.chf / posPrice) * 10000) / 100;
 
-[Challenge Position](${AppUrl(`/monitoring/${position.position}/challenge`)})
-[View Position](${AppUrl(`/monitoring/${position.position}`)})
-[View Owner Positions](${AppUrl(`/mypositions?address=${position.owner}`)})
+	return `🔴 *Position Undercollateralized*
 
-`;
+${priceBody(position, price)}
+   *Collateralization: ${ratio}%* 🔴
+
+[⚔️ Challenge](${AppUrl(`/monitoring/${position.position}/challenge`)}) · [📋 Position](${AppUrl(`/monitoring/${position.position}`)})`;
 }
 
 export function PositionPriceAlert(position: PositionQuery, price: PriceQuery, last: PositionPriceAlertState): string {
-	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
 	const posPrice = parseFloat(formatUnits(BigInt(position.price), 36 - position.collateralDecimals));
+	const ratio = Math.round((price.price.chf / posPrice) * 10000) / 100;
 
-	return `
-*Position Price Alert*
+	return `🚨 *Price Alert*
 
-Position: ${position.position}
-Collateral: ${position.collateralName} (${position.collateralSymbol})
-Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
+${priceBody(position, price)}
+   *Collateralization: ${ratio}%* 🚨
 
-Position Price: ${posPrice} ZCHF
-CoinGecko Price: ${price.price.chf} ZCHF
-Collateralization: ${Math.round((price.price.chf / posPrice) * 10000) / 100}%
-
-[Challenge Position](${AppUrl(`/monitoring/${position.position}/challenge`)})
-[View Position](${AppUrl(`/monitoring/${position.position}`)})
-[View Owner Positions](${AppUrl(`/mypositions?address=${position.owner}`)})
-
-`;
+[⚔️ Challenge](${AppUrl(`/monitoring/${position.position}/challenge`)}) · [📋 Position](${AppUrl(`/monitoring/${position.position}`)})`;
 }
 
 export function PositionPriceWarning(position: PositionQuery, price: PriceQuery, last: PositionPriceAlertState): string {
-	const bal: number = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
 	const posPrice = parseFloat(formatUnits(BigInt(position.price), 36 - position.collateralDecimals));
+	const ratio = Math.round((price.price.chf / posPrice) * 10000) / 100;
 
-	return `
-*Position Price Warning*
+	return `⚠️ *Price Warning*
 
-Position: ${position.position}
-Collateral: ${position.collateralName} (${position.collateralSymbol})
-Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
+${priceBody(position, price)}
+   *Collateralization: ${ratio}%* ⚠️
 
-Position Price: ${posPrice} ZCHF
-CoinGecko Price: ${price.price.chf} ZCHF
-Collateralization: ${Math.round((price.price.chf / posPrice) * 10000) / 100}%
-
-[Challenge Position](${AppUrl(`/monitoring/${position.position}/challenge`)})
-[View Position](${AppUrl(`/monitoring/${position.position}`)})
-[View Owner Positions](${AppUrl(`/mypositions?address=${position.owner}`)})
-
-`;
+[⚔️ Challenge](${AppUrl(`/monitoring/${position.position}/challenge`)}) · [📋 Position](${AppUrl(`/monitoring/${position.position}`)})`;
 }

--- a/src/integrations/telegram/messages/PositionProposal.message.ts
+++ b/src/integrations/telegram/messages/PositionProposal.message.ts
@@ -1,5 +1,5 @@
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency } from 'utils/format';
+import { formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
@@ -7,30 +7,29 @@ export function PositionProposalMessage(position: PositionQuery): string {
 	const bal = formatUnits(BigInt(position.collateralBalance), position.collateralDecimals);
 	const min = formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals);
 	const price = formatUnits(BigInt(position.price), 36 - position.collateralDecimals);
+	const start = new Date(position.start * 1000).toUTCString();
+	const expiryDays = Math.floor((position.expiration * 1000 - Date.now()) / 1000 / 60 / 60 / 24);
+	const auctionHours = Math.floor(position.challengePeriod / 3600);
 
-	return `
-*New Position Proposal*
+	return `📋 *New Position Proposal*
 
-Start: ${new Date(position.start * 1000).toString().split(' ').splice(0, 5).join(' ')}
-Position: ${position.position}
-Owner: ${position.owner}
-Minting Limit: ${formatCurrency(formatUnits(BigInt(position.limitForClones), 18), 2, 2)} ZCHF
-Annual Interest: ${formatCurrency(position.annualInterestPPM / 10000, 1, 1)}%
-Retained Reserve: ${formatCurrency(position.reserveContribution / 10000, 1, 1)}%
-Auction Duration: ${Math.floor(position.challengePeriod / 60 / 60)} hours
-Expiration: ${Math.floor((position.expiration * 1000 - Date.now()) / 1000 / 60 / 60 / 24)} days
+📅 Start: *${start}*
+🏦 Position: \`${shortenString(position.position)}\` (v${position.version})
+👤 Owner: \`${shortenString(position.owner)}\`
 
-Collateral: ${position.collateralName} (${position.collateralSymbol})
-At: ${position.collateral}
-Balance: ${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}
-Bal. min.: ${formatCurrency(min, 2, 2)} ${position.collateralSymbol}
-Price: ${formatCurrency(price, 2, 2)} ZCHF
+💎 Collateral: *${position.collateralName} (${position.collateralSymbol})*
+   Address: \`${shortenString(position.collateral)}\`
+   Balance: *${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}*
+   Min Balance: *${formatCurrency(min, 2, 2)} ${position.collateralSymbol}*
+   Liq. Price: *${formatCurrency(price, 2, 2)} ZCHF*
 
-[Challenge Position](${AppUrl(`/monitoring/${position.position}/challenge`)})
-[Veto Position](${AppUrl(`/monitoring/${position.position}/veto`)})
+📊 Terms
+   Limit: *${formatCurrency(formatUnits(BigInt(position.limitForClones), 18), 2, 2)} ZCHF*
+   Interest: *${formatCurrency(position.annualInterestPPM / 10000, 1, 1)}%* APY
+   Reserve: *${formatCurrency(position.reserveContribution / 10000, 1, 1)}%*
+   Auction: *${auctionHours} hours*
+   Expiry: *${expiryDays} days*
 
-[Explorer Position](${ExplorerAddressUrl(position.position)})
-[Explorer Owner](${ExplorerAddressUrl(position.owner)}) 
-[Explorer Collateral](${ExplorerAddressUrl(position.collateral)}) 
-                        `;
+[⚔️ Challenge](${AppUrl(`/monitoring/${position.position}/challenge`)}) · [🚫 Veto](${AppUrl(`/monitoring/${position.position}/veto`)})
+[🔍 Position](${ExplorerAddressUrl(position.position)}) · [🔍 Owner](${ExplorerAddressUrl(position.owner)})`;
 }

--- a/src/integrations/telegram/messages/StartUp.message.ts
+++ b/src/integrations/telegram/messages/StartUp.message.ts
@@ -2,20 +2,15 @@ import { AppUrl } from 'utils/func-helper';
 import { mainnet } from 'viem/chains';
 
 export function StartUpMessage(handles: string[]): string {
-	return `
-*Hello again, from the Frankencoin API Bot!*
+	const subs = handles
+		.filter((h) => h !== '/help')
+		.join(' · ');
 
-I have updated and restarted and am back online, listening to changes within the Frankencoin ecosystem.
+	return `🔄 *Frankencoin Bot Restarted*
 
-*Available subscription handles:*
-${handles.join('\n')}
+Back online and monitoring the ${mainnet.name} ecosystem.
 
-*Environment*
-Api Version: ${process.env.npm_package_version}
-Chain/Network: ${mainnet.name} (${mainnet.id})
-Time: ${new Date().toString().split(' ').slice(0, 5).join(' ')}
+📡 ${subs}
 
-[Goto App](${AppUrl('')})
-[Github Api](https://github.com/Frankencoin-ZCHF/frankencoin-api)
-`;
+v${process.env.npm_package_version} · [🌐 App](${AppUrl('')}) · [📦 GitHub](https://github.com/Frankencoin-ZCHF/frankencoin-api)`;
 }

--- a/src/integrations/telegram/messages/WelcomeGroup.message.ts
+++ b/src/integrations/telegram/messages/WelcomeGroup.message.ts
@@ -2,20 +2,26 @@ import { AppUrl } from 'utils/func-helper';
 import { mainnet } from 'viem/chains';
 
 export function WelcomeGroupMessage(group: string | number, handles: string[]): string {
-	return `
-*Welcome to the Frankencoin API Bot*
+	const subscriptions = handles
+		.filter((h) => h !== '/help')
+		.map((h) => {
+			const labels: Record<string, string> = {
+				'/MintingUpdates': '📊 /MintingUpdates — new minting transactions',
+				'/PriceAlerts': '⚠️ /PriceAlerts — collateral price warnings',
+				'/DailyInfos': '📅 /DailyInfos — weekly ecosystem summary',
+			};
+			return labels[h] ?? h;
+		})
+		.join('\n');
 
-If you receive this message, it means the bot recognized this chat. (${group})
+	return `👋 *Welcome to Frankencoin Bot*
 
-*Available subscription handles:*
-${handles.join('\n')}
+This chat (\`${group}\`) is now connected to the Frankencoin ecosystem monitor on ${mainnet.name}.
 
-*Environment*
-Api Version: ${process.env.npm_package_version}
-Chain/Network: ${mainnet.name} (${mainnet.id})
-Time: ${new Date().toString().split(' ').slice(0, 5).join(' ')}
+📡 *Optional Subscriptions*
+${subscriptions}
 
-[Goto App](${AppUrl('')})
-[Github Api](https://github.com/Frankencoin-ZCHF/frankencoin-api)
-                        `;
+Use /subscribe to manage alerts or /help for status.
+
+v${process.env.npm_package_version} · [🌐 App](${AppUrl('')}) · [📦 GitHub](https://github.com/Frankencoin-ZCHF/frankencoin-api)`;
 }

--- a/src/integrations/telegram/telegram.service.ts
+++ b/src/integrations/telegram/telegram.service.ts
@@ -475,7 +475,35 @@ export class TelegramService {
 			.map(([chatId]) => chatId);
 	}
 
+	private buildSubscriptionKeyboard(chatId: string): TelegramBot.InlineKeyboardButton[][] {
+		const subs = this.telegramGroupState.subscription[chatId] || {};
+		return [
+			[{ text: `${subs['MintingUpdates'] ? '✅' : '⬜'} Minting Updates`, callback_data: 'sub:MintingUpdates' }],
+			[{ text: `${subs['PriceAlerts'] ? '✅' : '⬜'} Price Alerts`, callback_data: 'sub:PriceAlerts' }],
+			[{ text: `${subs['DailyInfos'] ? '✅' : '⬜'} Daily Infos (weekly)`, callback_data: 'sub:DailyInfos' }],
+		];
+	}
+
+	private async sendSubscriptionMenu(chatId: number | string) {
+		const id = chatId.toString();
+		await this.sendMessage(id, '📡 *Manage Subscriptions*\n\nTap to toggle an alert type on or off:');
+		await this.bot.sendMessage(id, '\u200b', {
+			reply_markup: { inline_keyboard: this.buildSubscriptionKeyboard(id) },
+		});
+	}
+
 	async applyListener() {
+		try {
+			await this.bot.setMyCommands([
+				{ command: 'start', description: 'Connect this chat & show info' },
+				{ command: 'help', description: 'Show status & subscriptions' },
+				{ command: 'subscribe', description: 'Manage alert subscriptions' },
+			]);
+			this.logger.log('Bot command menu registered');
+		} catch (e) {
+			this.logger.warn(`Failed to set bot commands: ${e.message}`);
+		}
+
 		const toggle = (handle: string, msg: TelegramBot.Message) => {
 			if (handle !== msg.text) return;
 			const group = msg.chat.id.toString();
@@ -483,10 +511,10 @@ export class TelegramService {
 			const chatSubs = this.telegramGroupState.subscription[group] || {};
 			if (chatSubs[key]) {
 				delete chatSubs[key];
-				this.sendMessage(group, `Removed from subscription: \n${handle}`);
+				this.sendMessage(group, `⬜ Unsubscribed from *${handle}*`);
 			} else {
 				chatSubs[key] = true;
-				this.sendMessage(group, `Added to subscription: \n${handle}`);
+				this.sendMessage(group, `✅ Subscribed to *${handle}*`);
 			}
 			this.telegramGroupState.subscription[group] = chatSubs;
 			this.writeBackupGroups([group]);
@@ -494,12 +522,44 @@ export class TelegramService {
 
 		this.bot.on('message', async (m) => {
 			if (this.upsertTelegramGroup(m.chat.id) == true) await this.writeBackupGroups([String(m.chat.id)]);
-			if (m.text === '/help')
+
+			if (m.text === '/start' || m.text === '/help') {
 				this.sendMessage(
 					m.chat.id,
 					HelpMessage(this.telegramHandles, this.telegramGroupState.subscription[m.chat.id.toString()] || {})
 				);
-			else this.telegramHandles.forEach((h) => toggle(h, m));
+			} else if (m.text === '/subscribe') {
+				await this.sendSubscriptionMenu(m.chat.id);
+			} else {
+				this.telegramHandles.forEach((h) => toggle(h, m));
+			}
+		});
+
+		this.bot.on('callback_query', async (query) => {
+			if (!query.data?.startsWith('sub:')) return;
+			const handle = query.data.replace('sub:', '');
+			const chatId = query.message.chat.id.toString();
+
+			const chatSubs = this.telegramGroupState.subscription[chatId] || {};
+			if (chatSubs[handle]) {
+				delete chatSubs[handle];
+			} else {
+				chatSubs[handle] = true;
+			}
+			this.telegramGroupState.subscription[chatId] = chatSubs;
+			await this.writeBackupGroups([chatId]);
+
+			try {
+				await this.bot.editMessageReplyMarkup(
+					{ inline_keyboard: this.buildSubscriptionKeyboard(chatId) },
+					{ chat_id: query.message.chat.id, message_id: query.message.message_id }
+				);
+			} catch (_) {}
+
+			const isOn = !!chatSubs[handle];
+			await this.bot.answerCallbackQuery(query.id, {
+				text: isOn ? `✅ Subscribed to ${handle}` : `⬜ Unsubscribed from ${handle}`,
+			});
 		});
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ async function bootstrap() {
 
 	const document = SwaggerModule.createDocument(api, config);
 	SwaggerModule.setup('/', api, document, {
-		swaggerOptions: { persistAuthorization: true },
+		swaggerOptions: { persistAuthorization: true, docExpansion: 'none' },
 	});
 
 	await api.listen(process.env.PORT || 3000);

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,4 +1,4 @@
-import { Address } from 'viem';
+import { Address, getAddress } from 'viem';
 
 export const formatCurrency = (value: string | number, minimumFractionDigits = 0, maximumFractionDigits = 2) => {
 	const amount = typeof value === 'string' ? parseFloat(value) : value;
@@ -24,6 +24,24 @@ export function formatFloat(value: bigint, digits: number = 18) {
 export function normalizeAddress(addr: string): Address {
 	return addr.toLowerCase() as Address;
 }
+
+export const shortenString = (str: string) => {
+	return str.substring(0, 6) + '...' + str.substring(str.length - 4);
+};
+
+export const shortenStringAdjust = (str: string, length: number) => {
+	if (str.length <= 2 * length) return str;
+	return str.substring(0, length) + ' ... ' + str.substring(str.length - length);
+};
+
+export const shortenAddress = (address: Address): string => {
+	try {
+		const formattedAddress = getAddress(address);
+		return shortenString(formattedAddress);
+	} catch {
+		throw new TypeError("Invalid input, address can't be parsed");
+	}
+};
 
 export function timestampToSeconds(ms: number | string) {
 	return String(Math.floor(Number(ms) / 1000));


### PR DESCRIPTION
## Summary

- **Telegram bot menu** — registers `/start`, `/help`, `/subscribe` commands via `setMyCommands` so Telegram shows a native command menu
- **Inline keyboard subscriptions** — `/subscribe` sends a live-updating inline keyboard; tapping toggles MintingUpdates / PriceAlerts / DailyInfos and updates the checkmark in-place without re-sending
- **Message overhaul** — all 18 message templates updated with emojis, `shortenString()` on addresses, cleaner field grouping, `toUTCString()` dates, and consolidated link lines
- **`scripts/send-telegram-mocks.ts`** — sends all 21 message variants to a target chat for previewing; run with `yarn telegram:mocks`
- **Debug HTML scripts** — standalone browser tools for inspecting FPS, Savings, and TotalSupply data against live API endpoints (`scripts/fps-debug.html`, `scripts/savings-debug.html`, `scripts/totalsupply-debug.html`)
- **Swagger collapse** — all endpoint groups collapsed by default on docs load (`docExpansion: 'none'`)

## Test plan

- [x] Send `/start`, `/help`, `/subscribe` to the bot — verify menu appears and inline keyboard toggles subscriptions correctly
- [x] Run `TELEGRAM_TEST_CHAT_ID=<id> yarn telegram:mocks` — verify all 21 message types render correctly
- [x] Open debug HTML scripts in browser against local or staging API
- [ ] Open `/` on the API — verify Swagger loads with all groups collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)