### PR TITLE
fix: resolve /help crash and /subscribe inline keyboard

### DIFF
--- a/src/integrations/telegram/telegram.service.ts
+++ b/src/integrations/telegram/telegram.service.ts
@@ -486,10 +486,14 @@ export class TelegramService {
 
 	private async sendSubscriptionMenu(chatId: number | string) {
 		const id = chatId.toString();
-		await this.sendMessage(id, '📡 *Manage Subscriptions*\n\nTap to toggle an alert type on or off:');
-		await this.bot.sendMessage(id, '\u200b', {
-			reply_markup: { inline_keyboard: this.buildSubscriptionKeyboard(id) },
-		});
+		try {
+			await this.bot.sendMessage(id, '📡 *Manage Subscriptions*\n\nTap to toggle an alert type on or off:', {
+				parse_mode: 'Markdown',
+				reply_markup: { inline_keyboard: this.buildSubscriptionKeyboard(id) },
+			});
+		} catch (error) {
+			this.logger.warn(`Failed to send subscription menu to ${id}: ${error?.message}`);
+		}
 	}
 
 	async applyListener() {
@@ -524,7 +528,7 @@ export class TelegramService {
 			if (this.upsertTelegramGroup(m.chat.id) == true) await this.writeBackupGroups([String(m.chat.id)]);
 
 			if (m.text === '/start' || m.text === '/help') {
-				this.sendMessage(
+				await this.sendMessage(
 					m.chat.id,
 					HelpMessage(this.telegramHandles, this.telegramGroupState.subscription[m.chat.id.toString()] || {})
 				);


### PR DESCRIPTION
## Summary
- `/help` crashed the process due to an unhandled promise rejection — `sendMessage` was not awaited in the message handler, so any rejection escaped into the bluebird queue and exited with code 1
- `/subscribe` showed the header text but no interactive buttons — the menu was split across two messages, and the second call (a zero-width space with the inline keyboard) had no error handling and was failing silently

## Changes
- Added `await` to `sendMessage` call in the `/start` / `/help` handler
- Merged `sendSubscriptionMenu` into a single `bot.sendMessage` with the text and `inline_keyboard` combined, wrapped in try/catch

## Test plan
- [x] Send `/help` — bot replies without crashing
- [x] Send `/subscribe` — single message appears with all three toggle buttons visible and interactive
- [x] Click a toggle button — checkbox flips and state is persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)