### PR TITLE
feat(prices): add 2025 EOY prices, new tokens, and dynamic history fallback

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
 Copyright (c) 2024 frankencoin
-Copyright (c) 2024 samclassix
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/modules/prices/prices.history.service.ts
+++ b/src/modules/prices/prices.history.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { PricesService } from './prices.service';
 import { ERC20Info, PriceHistoryRatio, PriceQueryObjectArray } from './prices.types';
 import { PriceHistoryQueryObjectArray } from '../../../exports';
@@ -14,7 +14,7 @@ import { mainnet } from 'viem/chains';
 import { ADDRESS, StablecoinBridgeABI } from '@frankencoin/zchf';
 
 @Injectable()
-export class PricesHistoryService {
+export class PricesHistoryService implements OnModuleInit {
 	private readonly logger = new Logger(this.constructor.name);
 	private fetchedHistory: PriceHistoryQueryObjectArray = {};
 	private fetchedHistoryRatio: PriceHistoryRatio = {
@@ -32,6 +32,10 @@ export class PricesHistoryService {
 	) {
 		this.readBackupHistoryQuery();
 		this.readBackupHistoryRatio();
+	}
+
+	onModuleInit() {
+		this.prices.registerHistoryService(this);
 	}
 
 	async readBackupHistoryQuery() {

--- a/src/modules/prices/prices.service.ts
+++ b/src/modules/prices/prices.service.ts
@@ -21,6 +21,11 @@ import { ADDRESS, ChainMain, SupportedChain } from '@frankencoin/zchf';
 import { PrismaService } from 'core/database/prisma.service';
 import { mainnet } from 'viem/chains';
 import { getEndOfYearPrice } from './yearly.service';
+import { PriceHistoryQueryObjectArray } from '../../../exports';
+
+interface IHistoryService {
+	getHistory(): PriceHistoryQueryObjectArray;
+}
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ContractBlacklist, ContractWhitelist } from './prices.mgm';
 import { getChain } from 'utils/func-helper';
@@ -32,6 +37,11 @@ export class PricesService {
 
 	private fetchedPrices: PriceQueryObjectArray = {};
 	private fetchedMarketChart: PriceMarketChartObject = { prices: [], market_caps: [], total_volumes: [] };
+	private historyService: IHistoryService | null = null;
+
+	registerHistoryService(service: IHistoryService) {
+		this.historyService = service;
+	}
 
 	constructor(
 		private readonly prisma: PrismaService,
@@ -290,7 +300,11 @@ export class PricesService {
 						const priceCurrent = parseUnits(String(this.fetchedPrices[c].price.chf), 18);
 						p = priceCurrent;
 					} else {
-						const priceHistory = getEndOfYearPrice({ year: y, contract: selected.collateral });
+						const priceHistory = getEndOfYearPrice({
+							year: y,
+							contract: selected.collateral,
+							history: this.historyService?.getHistory(),
+						});
 						p = priceHistory;
 					}
 

--- a/src/modules/prices/yearly.service.ts
+++ b/src/modules/prices/yearly.service.ts
@@ -1,9 +1,11 @@
 import { Address, parseUnits } from 'viem';
 import { normalizeAddress } from 'utils/format';
+import { PriceHistoryQueryObjectArray } from '../../../exports';
 
 interface Props {
 	year: string | number;
 	contract: Address;
+	history?: PriceHistoryQueryObjectArray;
 }
 
 type ContractYearlyMap = {
@@ -12,57 +14,82 @@ type ContractYearlyMap = {
 	};
 };
 
-export function getEndOfYearPrice({ year, contract }: Props) {
+export function getEndOfYearPrice({ year, contract, history }: Props) {
 	const data: ContractYearlyMap = {
 		// Wrapped Ether
-		['0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'.toLowerCase()]: {
+		[normalizeAddress('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2')]: {
 			['2023']: 1948.008419,
 			['2024']: 3083.55628,
+			['2025']: 2364.08,
 		},
 		// Liquid Staked ETH
-		['0x8c1BEd5b9a0928467c9B1341Da1D7BD5e10b6549'.toLowerCase()]: {
+		[normalizeAddress('0x8c1BEd5b9a0928467c9B1341Da1D7BD5e10b6549')]: {
 			['2023']: 2017.941921,
 			['2024']: 3283.370727,
+			['2025']: 2597.26,
 		},
 		// Wrapped BTC
-		['0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'.toLowerCase()]: {
+		[normalizeAddress('0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599')]: {
 			['2023']: 35541.6309,
 			['2024']: 85926.48636,
+			['2025']: 69208.67,
 		},
 		// Uniswap
-		['0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984'.toLowerCase()]: {
+		[normalizeAddress('0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984')]: {
 			['2023']: 6.290979,
 			['2024']: 12.273699,
+			['2025']: 4.6231,
 		},
 		// Boss Info AG
-		['0x2E880962A9609aA3eab4DEF919FE9E917E99073B'.toLowerCase()]: {
+		[normalizeAddress('0x2E880962A9609aA3eab4DEF919FE9E917E99073B')]: {
 			['2023']: 10.15,
 			['2024']: 10.19,
+			['2025']: 10.195,
 		},
 		// Draggable quitt.shares
-		['0x8747a3114Ef7f0eEBd3eB337F745E31dBF81a952'.toLowerCase()]: {
+		[normalizeAddress('0x8747a3114Ef7f0eEBd3eB337F745E31dBF81a952')]: {
 			['2023']: 8.21,
 			['2024']: 8.05,
+			['2025']: 8.5,
 		},
 		// RealUnit Shares
-		['0x553C7f9C780316FC1D34b8e14ac2465Ab22a090B'.toLowerCase()]: {
+		[normalizeAddress('0x553C7f9C780316FC1D34b8e14ac2465Ab22a090B')]: {
 			['2023']: 1.04,
 			['2024']: 1.13,
+			['2025']: 1.38,
 		},
 		// Wrapped liquid staked Ether 2.0
-		['0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'.toLowerCase()]: {
+		[normalizeAddress('0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0')]: {
 			['2023']: 2618,
 			['2024']: 3983,
+			['2025']: 2891.88,
 		},
 		// Coinbase Wrapped BTC
-		['0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf'.toLowerCase()]: {
+		[normalizeAddress('0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf')]: {
 			['2023']: 35541.6309,
 			['2024']: 85926.48636,
+			['2025']: 69208.67,
 		},
 		// Curve DAO Token
-		['0xD533a949740bb3306d119CC777fa900bA034cd52'.toLowerCase()]: {
+		[normalizeAddress('0xD533a949740bb3306d119CC777fa900bA034cd52')]: {
 			['2023']: 0.623,
 			['2024']: 0.929,
+			['2025']: 0.29,
+		},
+		// Frankencoin Pool Share
+		[normalizeAddress('0x1bA26788dfDe592fec8bcB0Eaff472a42BE341B2')]: {
+			['2024']: 1179.0,
+			['2025']: 1191.04,
+		},
+		// Paxos Gold
+		[normalizeAddress('0x45804880De22913dAFE09f4980848ECE6EcbAf78')]: {
+			['2024']: 2378.08,
+			['2025']: 3438.47,
+		},
+		// Tether Gold
+		[normalizeAddress('0x68749665FF8D2d112Fa859AA293F07A622782F38')]: {
+			['2024']: 2378.08,
+			['2025']: 3438.47,
 		},
 	};
 
@@ -71,9 +98,21 @@ export function getEndOfYearPrice({ year, contract }: Props) {
 	if (entry) {
 		const price = entry[String(year)];
 		if (price) return parseUnits(String(price), 18);
+	}
 
-		const fallBack = entry[String(Number(year) - 1)];
-		if (fallBack) return parseUnits(String(fallBack), 18);
+	if (history) {
+		const historyEntry = history[normalizeAddress(contract)];
+		if (historyEntry?.history) {
+			const yearEndMs = new Date(Number(year) + 1, 0, 1).getTime();
+			const yearStartMs = new Date(Number(year), 0, 1).getTime();
+			const timestamps = Object.keys(historyEntry.history).map(Number);
+
+			const withinYear = timestamps.filter((t) => t >= yearStartMs && t < yearEndMs).sort((a, b) => b - a);
+			if (withinYear.length > 0) return parseUnits(String(historyEntry.history[withinYear[0]]), 18);
+
+			const before = timestamps.filter((t) => t < yearEndMs).sort((a, b) => b - a);
+			if (before.length > 0) return parseUnits(String(historyEntry.history[before[0]]), 18);
+		}
 	}
 
 	return BigInt(0);


### PR DESCRIPTION
## Summary
- Add 2025 end-of-year prices for all existing collateral tokens (WETH, wstETH, WBTC, UNI, cbBTC, CRV, wstETH2, Boss Info, quitt.shares, RealUnit)
- Add three new tokens to the yearly price map: FPS (Frankencoin Pool Share), PAXG (Paxos Gold), XAUt (Tether Gold)
- Introduce `IHistoryService` interface and `registerHistoryService` pattern so `PricesService` can dynamically fall back to on-chain price history when static EOY data is missing
- `PricesHistoryService` now implements `OnModuleInit` to self-register with `PricesService`
- Remove individual copyright line from LICENSE

## Test plan
- [ ] Verify 2025 EOY prices are returned correctly for existing collaterals
- [ ] Verify FPS, PAXG, and XAUt resolve correctly for 2024 and 2025
- [ ] Verify dynamic history fallback is used when a year/contract has no static entry
- [ ] Confirm service registration wiring works on module init (no circular dep issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)