### PR TITLE
fix: harden Telegram messages against Markdown injection

### DIFF
--- a/src/integrations/telegram/messages/BidTaken.message.ts
+++ b/src/integrations/telegram/messages/BidTaken.message.ts
@@ -1,10 +1,13 @@
 import { BidsQueryItem, ChallengesQueryItem } from 'modules/challenges/challenges.types';
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency, shortenString } from 'utils/format';
+import { escapeMd, formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
 export function BidTakenMessage(position: PositionQuery, challenge: ChallengesQueryItem, bid: BidsQueryItem): string {
+	const sym = escapeMd(position.collateralSymbol);
+	const name = escapeMd(position.collateralName);
+
 	return `💸 *Bid Taken*
 
 🏦 Position: \`${shortenString(bid.position)}\` (v${position.version})
@@ -12,11 +15,11 @@ export function BidTakenMessage(position: PositionQuery, challenge: ChallengesQu
 📋 Challenge: #${bid.number} · Bid: #${bid.numberBid}
 🏷 Type: *${bid.bidType}*
 
-💎 Collateral: *${position.collateralName} (${position.collateralSymbol})*
-   Challenge Size: *${formatCurrency(formatUnits(bid.challengeSize, position.collateralDecimals))} ${position.collateralSymbol}*
-   Bid Filled: *${formatCurrency(formatUnits(bid.filledSize, position.collateralDecimals))} ${position.collateralSymbol}*
+💎 Collateral: *${name} (${sym})*
+   Challenge Size: *${formatCurrency(formatUnits(bid.challengeSize, position.collateralDecimals))} ${sym}*
+   Bid Filled: *${formatCurrency(formatUnits(bid.filledSize, position.collateralDecimals))} ${sym}*
    Bid Amount: *${formatCurrency(formatUnits(bid.bid, 18))} ZCHF*
-   Bid Price: *${formatCurrency(formatUnits(bid.price, 36 - position.collateralDecimals))} ZCHF/${position.collateralSymbol}*
+   Bid Price: *${formatCurrency(formatUnits(bid.price, 36 - position.collateralDecimals))} ZCHF/${sym}*
 
 [💸 Buy in Auction](${AppUrl(`/monitoring/${bid.position}/auction/${bid.number}`)}) · [📋 Position](${AppUrl(`/monitoring/${bid.position}`)})
 [🔍 Bidder](${ExplorerAddressUrl(bid.bidder)}) · [🔍 Position](${ExplorerAddressUrl(bid.position)})`;

--- a/src/integrations/telegram/messages/CCIPProposal.message.ts
+++ b/src/integrations/telegram/messages/CCIPProposal.message.ts
@@ -1,5 +1,5 @@
 import { ApiCCIPProposal } from 'modules/bridge/bridge.types';
-import { shortenString } from 'utils/format';
+import { escapeMd, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl, ExplorerTxUrl, getChain } from 'utils/func-helper';
 import { ChainId } from '@frankencoin/zchf';
 import { Chain } from 'viem';
@@ -19,7 +19,7 @@ export function CCIPProposalMessage(proposal: ApiCCIPProposal): string {
 	return `⚠️ *New CCIP Proposal*
 
 🌐 Chain: *${chain?.name}* (${proposal.chainId})
-📋 Type: *${typeLabel[proposal.type] ?? proposal.type}*
+📋 Type: *${escapeMd(typeLabel[proposal.type] ?? proposal.type ?? '')}*
 👤 Proposer: \`${proposal.proposer ?? 'unknown'}\`
 ⏰ Veto Until: *${deadline.toUTCString()}*
 ${details}

--- a/src/integrations/telegram/messages/CCIPProposalDenied.message.ts
+++ b/src/integrations/telegram/messages/CCIPProposalDenied.message.ts
@@ -1,5 +1,5 @@
 import { ApiCCIPProposal } from 'modules/bridge/bridge.types';
-import { shortenString } from 'utils/format';
+import { escapeMd, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl, ExplorerTxUrl, getChain } from 'utils/func-helper';
 import { ChainId } from '@frankencoin/zchf';
 import { Chain } from 'viem';
@@ -17,7 +17,7 @@ export function CCIPProposalDeniedMessage(proposal: ApiCCIPProposal): string {
 	return `🚫 *CCIP Proposal Denied*
 
 🌐 Chain: *${chain?.name}* (${proposal.chainId})
-📋 Type: *${typeLabel[proposal.type] ?? proposal.type}*
+📋 Type: *${escapeMd(typeLabel[proposal.type] ?? proposal.type ?? '')}*
 👤 Proposer: \`${proposal.proposer ?? 'unknown'}\`
 🔑 Hash: \`${shortenString(proposal.hash)}\`
 

--- a/src/integrations/telegram/messages/CCIPProposalEnacted.message.ts
+++ b/src/integrations/telegram/messages/CCIPProposalEnacted.message.ts
@@ -1,5 +1,5 @@
 import { ApiCCIPProposal } from 'modules/bridge/bridge.types';
-import { shortenString } from 'utils/format';
+import { escapeMd, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl, ExplorerTxUrl, getChain } from 'utils/func-helper';
 import { ChainId } from '@frankencoin/zchf';
 import { Chain } from 'viem';
@@ -17,7 +17,7 @@ export function CCIPProposalEnactedMessage(proposal: ApiCCIPProposal): string {
 	return `✅ *CCIP Proposal Enacted*
 
 🌐 Chain: *${chain?.name}* (${proposal.chainId})
-📋 Type: *${typeLabel[proposal.type] ?? proposal.type}*
+📋 Type: *${escapeMd(typeLabel[proposal.type] ?? proposal.type ?? '')}*
 👤 Proposer: \`${proposal.proposer ?? 'unknown'}\`
 🔑 Hash: \`${shortenString(proposal.hash)}\`
 

--- a/src/integrations/telegram/messages/ChallengeStarted.message.ts
+++ b/src/integrations/telegram/messages/ChallengeStarted.message.ts
@@ -1,6 +1,6 @@
 import { ChallengesQueryItem } from 'modules/challenges/challenges.types';
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency, shortenString } from 'utils/format';
+import { escapeMd, formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
@@ -17,6 +17,9 @@ export function ChallengeStartedMessage(position: PositionQuery, challenge: Chal
 	const expirationFinal = Math.min(expirationVirtual, expirationPosition);
 	const phase1End = isQuickAuction ? undefined : startMs + duration;
 
+	const sym = escapeMd(position.collateralSymbol);
+	const name = escapeMd(position.collateralName);
+
 	return `⚔️ *Challenge Started*
 
 #${challenge.number} on \`${shortenString(position.position)}\` (v${position.version})
@@ -25,8 +28,8 @@ export function ChallengeStartedMessage(position: PositionQuery, challenge: Chal
 ⚔️ Challenger: \`${shortenString(challenge.challenger)}\`
 👤 Owner: \`${shortenString(position.owner)}\`
 
-💎 Collateral: *${position.collateralName} (${position.collateralSymbol})*
-   Size: *${formatCurrency(size, 2, 2)} ${position.collateralSymbol}* (min *${formatCurrency(min, 2, 2)}*)
+💎 Collateral: *${name} (${sym})*
+   Size: *${formatCurrency(size, 2, 2)} ${sym}* (min *${formatCurrency(min, 2, 2)}*)
    Starting Price: *${formatCurrency(price, 2, 2)} ZCHF*
    Duration: *${formatCurrency(duration / 1000 / 3600, 1, 1)} hours*
 

--- a/src/integrations/telegram/messages/MinterProposal.message.ts
+++ b/src/integrations/telegram/messages/MinterProposal.message.ts
@@ -1,5 +1,5 @@
 import { MinterQuery } from 'modules/ecosystem/ecosystem.minter.types';
-import { formatCurrency, shortenString } from 'utils/format';
+import { escapeMd, formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerTxUrl, getChain } from 'utils/func-helper';
 import { Chain } from 'viem';
 
@@ -14,7 +14,7 @@ export function MinterProposalMessage(minter: MinterQuery): string {
 💰 Fee: *${formatCurrency(minter.applicationFee / 1e18, 2, 2)} ZCHF*
 ⏱ Period: *${hours} hours*
 ⏰ Veto Until: *${vetoDeadline.toUTCString()}*
-💬 Message: ${minter.applyMessage || '—'}
+💬 Message: ${escapeMd(minter.applyMessage || '—')}
 
 [🏛️ Governance](${AppUrl('/governance')}) · [🔍 Explorer](${ExplorerTxUrl(minter.txHash, getChain(minter.chainId) as Chain)})`;
 }

--- a/src/integrations/telegram/messages/MinterProposalVetoed.message.ts
+++ b/src/integrations/telegram/messages/MinterProposalVetoed.message.ts
@@ -1,5 +1,5 @@
 import { MinterQuery } from 'modules/ecosystem/ecosystem.minter.types';
-import { formatCurrency, shortenString } from 'utils/format';
+import { escapeMd, formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerTxUrl, getChain } from 'utils/func-helper';
 import { Chain } from 'viem';
 
@@ -9,10 +9,10 @@ export function MinterProposalVetoedMessage(minter: MinterQuery): string {
 👤 Minter: \`${shortenString(minter.minter)}\`
 👤 Suggestor: \`${shortenString(minter.suggestor)}\`
 💰 Fee: *${formatCurrency(minter.applicationFee / 1e18, 2, 2)} ZCHF*
-💬 Apply: ${minter.applyMessage || '—'}
+💬 Apply: ${escapeMd(minter.applyMessage || '—')}
 
 🚫 Vetor: \`${shortenString(minter.vetor)}\`
-💬 Reason: ${minter.denyMessage || '—'}
+💬 Reason: ${escapeMd(minter.denyMessage || '—')}
 
 [🏛️ Governance](${AppUrl('/governance')}) · [🔍 Explorer](${ExplorerTxUrl(minter.denyTxHash, getChain(minter.chainId) as Chain)})`;
 }

--- a/src/integrations/telegram/messages/MintingUpdate.message.ts
+++ b/src/integrations/telegram/messages/MintingUpdate.message.ts
@@ -1,6 +1,6 @@
 import { MintingUpdateQuery } from 'modules/positions/positions.types';
 import { PriceQuery, PriceQueryObjectArray } from 'modules/prices/prices.types';
-import { formatCurrency, normalizeAddress, shortenString } from 'utils/format';
+import { escapeMd, formatCurrency, normalizeAddress, shortenString } from 'utils/format';
 import { formatUnits } from 'viem';
 import { AppUrl, ExplorerAddressUrl, ExplorerTxUrl } from 'utils/func-helper';
 
@@ -13,12 +13,15 @@ export function MintingUpdateMessage(minting: MintingUpdateQuery, prices: PriceQ
 	const timeframeDays = Math.round(minting.feeTimeframe / 86400);
 	const sign = mintedAdjusted >= 0 ? '+' : '-';
 
+	const sym = escapeMd(minting.collateralSymbol);
+	const name = escapeMd(minting.collateralName);
+
 	return `🔄 *New Minting*
 
 🏦 Position: \`${shortenString(minting.position)}\` (v${minting.version})
 👤 Owner: \`${shortenString(minting.owner)}\`
 
-💎 Collateral: *${minting.collateralName} (${minting.collateralSymbol})*
+💎 Collateral: *${name} (${sym})*
    Market Price: *${formatCurrency(marketPrice, 2)} ZCHF*
    Liq. Price: *${formatCurrency(liqPrice, 2)} ZCHF*
    *Ratio: ${formatCurrency(ratio * 100, 2)}%*

--- a/src/integrations/telegram/messages/PositionDenied.message.ts
+++ b/src/integrations/telegram/messages/PositionDenied.message.ts
@@ -1,5 +1,5 @@
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency, shortenString } from 'utils/format';
+import { escapeMd, formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
@@ -8,15 +8,18 @@ export function PositionDeniedMessage(position: PositionQuery): string {
 	const price = formatUnits(BigInt(position.price), 36 - position.collateralDecimals);
 	const denied = position.denyDate > 0 ? new Date(position.denyDate * 1000).toUTCString() : 'Unknown';
 
+	const sym = escapeMd(position.collateralSymbol);
+	const name = escapeMd(position.collateralName);
+
 	return `🚫 *Position Denied*
 
 📅 Denied: *${denied}*
 🏦 Position: \`${shortenString(position.position)}\`
 👤 Owner: \`${shortenString(position.owner)}\`
 
-💎 Collateral: *${position.collateralName} (${position.collateralSymbol})*
+💎 Collateral: *${name} (${sym})*
    Address: \`${shortenString(position.collateral)}\`
-   Balance: *${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}*
+   Balance: *${formatCurrency(bal, 2, 2)} ${sym}*
    Liq. Price: *${formatCurrency(price, 2, 2)} ZCHF*
 
 📊 Limit: *${formatCurrency(formatUnits(BigInt(position.limitForClones), 18), 2, 2)} ZCHF*

--- a/src/integrations/telegram/messages/PositionExpired.message.ts
+++ b/src/integrations/telegram/messages/PositionExpired.message.ts
@@ -1,5 +1,5 @@
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency, shortenString } from 'utils/format';
+import { escapeMd, formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
@@ -13,14 +13,17 @@ export function PositionExpiredMessage(position: PositionQuery): string {
 	const t1 = new Date(position.expiration * 1000 + duration);
 	const t2 = new Date(position.expiration * 1000 + 2 * duration);
 
+	const sym = escapeMd(position.collateralSymbol);
+	const name = escapeMd(position.collateralName);
+
 	const header = `💀 *Position Expired*
 
 🏦 Position: \`${shortenString(position.position)}\` (v${position.version})
 👤 Owner: \`${shortenString(position.owner)}\`
 
-💎 Collateral: *${position.collateralName} (${position.collateralSymbol})*
+💎 Collateral: *${name} (${sym})*
    Address: \`${shortenString(position.collateral)}\`
-   Balance: *${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}* (min *${formatCurrency(min, 2, 2)}*)
+   Balance: *${formatCurrency(bal, 2, 2)} ${sym}* (min *${formatCurrency(min, 2, 2)}*)
 
 💵 Minted: *${formatCurrency(formatUnits(BigInt(position.minted), 18), 2, 2)} ZCHF*
    Reserve: *${formatCurrency(position.reserveContribution / 10000, 1, 1)}%* · Auction: *${Math.floor(position.challengePeriod / 3600)} hours*`;
@@ -29,7 +32,7 @@ export function PositionExpiredMessage(position: PositionQuery): string {
 
 ⚔️ *Challenge Available*
    1x → 0x from: *${t0.toUTCString()}*
-   Price (1x): *${formatCurrency(price, 2, 2)} ZCHF/${position.collateralSymbol}*
+   Price (1x): *${formatCurrency(price, 2, 2)} ZCHF/${sym}*
    Zero at: *${t1.toUTCString()}*`;
 
 	const v2Body = `

--- a/src/integrations/telegram/messages/PositionExpiringSoon.message.ts
+++ b/src/integrations/telegram/messages/PositionExpiringSoon.message.ts
@@ -1,5 +1,5 @@
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency, shortenString } from 'utils/format';
+import { escapeMd, formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
@@ -11,6 +11,9 @@ export function PositionExpiringSoonMessage(position: PositionQuery): string {
 	const expiryDays = formatCurrency((position.expiration * 1000 - Date.now()) / 1000 / 60 / 60 / 24);
 	const auctionHours = Math.floor(position.challengePeriod / 3600);
 
+	const sym = escapeMd(position.collateralSymbol);
+	const name = escapeMd(position.collateralName);
+
 	return `⏰ *Position Expiring Soon*
 
 🏦 Position: \`${shortenString(position.position)}\` (v${position.version})
@@ -19,9 +22,9 @@ export function PositionExpiringSoonMessage(position: PositionQuery): string {
 📅 Expiry: *${expiryDate.toUTCString()}* (in *${expiryDays} days*)
 ⏱ Auction Duration: *${auctionHours} hours*
 
-💎 Collateral: *${position.collateralName} (${position.collateralSymbol})*
+💎 Collateral: *${name} (${sym})*
    Address: \`${shortenString(position.collateral)}\`
-   Balance: *${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}* (min *${formatCurrency(min, 2, 2)}*)
+   Balance: *${formatCurrency(bal, 2, 2)} ${sym}* (min *${formatCurrency(min, 2, 2)}*)
    Liq. Price: *${formatCurrency(price, 2, 2)} ZCHF*
 
 💵 Minted: *${formatCurrency(formatUnits(BigInt(position.minted), 18), 2, 2)} ZCHF*

--- a/src/integrations/telegram/messages/PositionPrice.message.ts
+++ b/src/integrations/telegram/messages/PositionPrice.message.ts
@@ -1,6 +1,6 @@
 import { PriceQuery } from 'modules/prices/prices.types';
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency, shortenString } from 'utils/format';
+import { escapeMd, formatCurrency, shortenString } from 'utils/format';
 import { AppUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 import { PositionPriceAlertState } from 'integrations/telegram/telegram.types';
@@ -8,10 +8,12 @@ import { PositionPriceAlertState } from 'integrations/telegram/telegram.types';
 function priceBody(position: PositionQuery, price: PriceQuery): string {
 	const bal = parseInt(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals - 2)) / 100;
 	const posPrice = parseFloat(formatUnits(BigInt(position.price), 36 - position.collateralDecimals));
-	const ratio = Math.round((price.price.chf / posPrice) * 10000) / 100;
+
+	const sym = escapeMd(position.collateralSymbol);
+	const name = escapeMd(position.collateralName);
 
 	return `🏦 Position: \`${shortenString(position.position)}\`
-💎 *${position.collateralName} (${position.collateralSymbol})* — *${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}*
+💎 *${name} (${sym})* — *${formatCurrency(bal, 2, 2)} ${sym}*
 
    Liq. Price: *${formatCurrency(posPrice, 2, 2)} ZCHF*
    Market Price: *${formatCurrency(price.price.chf, 2, 2)} ZCHF*`;

--- a/src/integrations/telegram/messages/PositionProposal.message.ts
+++ b/src/integrations/telegram/messages/PositionProposal.message.ts
@@ -1,5 +1,5 @@
 import { PositionQuery } from 'modules/positions/positions.types';
-import { formatCurrency, shortenString } from 'utils/format';
+import { escapeMd, formatCurrency, shortenString } from 'utils/format';
 import { AppUrl, ExplorerAddressUrl } from 'utils/func-helper';
 import { formatUnits } from 'viem';
 
@@ -11,16 +11,19 @@ export function PositionProposalMessage(position: PositionQuery): string {
 	const expiryDays = Math.floor((position.expiration * 1000 - Date.now()) / 1000 / 60 / 60 / 24);
 	const auctionHours = Math.floor(position.challengePeriod / 3600);
 
+	const sym = escapeMd(position.collateralSymbol);
+	const name = escapeMd(position.collateralName);
+
 	return `📋 *New Position Proposal*
 
 📅 Start: *${start}*
 🏦 Position: \`${shortenString(position.position)}\` (v${position.version})
 👤 Owner: \`${shortenString(position.owner)}\`
 
-💎 Collateral: *${position.collateralName} (${position.collateralSymbol})*
+💎 Collateral: *${name} (${sym})*
    Address: \`${shortenString(position.collateral)}\`
-   Balance: *${formatCurrency(bal, 2, 2)} ${position.collateralSymbol}*
-   Min Balance: *${formatCurrency(min, 2, 2)} ${position.collateralSymbol}*
+   Balance: *${formatCurrency(bal, 2, 2)} ${sym}*
+   Min Balance: *${formatCurrency(min, 2, 2)} ${sym}*
    Liq. Price: *${formatCurrency(price, 2, 2)} ZCHF*
 
 📊 Terms

--- a/src/integrations/telegram/telegram.service.ts
+++ b/src/integrations/telegram/telegram.service.ts
@@ -58,8 +58,8 @@ export class TelegramService {
 		private readonly bridge: BridgeService
 	) {
 		this.telegramState = {
-			minterApplied: this.startUpTime,
-			minterVetoed: this.startUpTime,
+			minterApplied: 1780036420000, // this.startUpTime,
+			minterVetoed: 1780036420000, // this.startUpTime,
 			leadrateProposal: this.startUpTime,
 			leadrateChanged: this.startUpTime,
 			positions: this.startUpTime,
@@ -167,10 +167,19 @@ export class TelegramService {
 				notFound: 'chat not found',
 				deleted: 'the group chat was deleted',
 				blocked: 'bot was blocked by the user',
+				parseEntities: 'parse entities',
 			};
 
 			if (typeof error === 'object') {
-				if (error?.message.includes(msg.deleted)) {
+				if (error?.message.includes(msg.parseEntities)) {
+					// Markdown parsing failed — retry as plain text so the alert is never lost
+					this.logger.warn(`Markdown parse error for group ${group}, retrying as plain text`);
+					try {
+						await this.bot.sendMessage(group.toString(), message, { disable_web_page_preview: true });
+					} catch (e2) {
+						this.logger.warn(`Plain text fallback also failed for group ${group}: ${e2?.message}`);
+					}
+				} else if (error?.message.includes(msg.deleted)) {
 					this.logger.warn(msg.deleted + `: ${group}`);
 					this.removeTelegramGroup(group);
 				} else if (error?.message.includes(msg.notFound)) {

--- a/src/integrations/telegram/telegram.service.ts
+++ b/src/integrations/telegram/telegram.service.ts
@@ -58,8 +58,8 @@ export class TelegramService {
 		private readonly bridge: BridgeService
 	) {
 		this.telegramState = {
-			minterApplied: 1780036420000, // this.startUpTime,
-			minterVetoed: 1780036420000, // this.startUpTime,
+			minterApplied: this.startUpTime,
+			minterVetoed: this.startUpTime,
 			leadrateProposal: this.startUpTime,
 			leadrateChanged: this.startUpTime,
 			positions: this.startUpTime,

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -50,3 +50,8 @@ export function timestampToSeconds(ms: number | string) {
 export function timestampStartOfDay(ms: number | string) {
 	return String(Number(ms) - (Number(ms) % 86_400_000));
 }
+
+// Escape Telegram MarkdownV1 special characters in user-supplied strings
+export function escapeMd(text: string): string {
+	return String(text).replace(/[\\*_`[]/g, '\\$&');
+}


### PR DESCRIPTION
## Summary

- Add `escapeMd()` to `utils/format.ts` — escapes `\`, `*`, `_`, `` ` ``, `[` for Telegram MarkdownV1
- Apply `escapeMd` to all attacker-controlled on-chain fields across **13 message templates**: `collateralName`, `collateralSymbol` (token contract — attacker-controlled), `applyMessage` / `denyMessage` (free-text proposal fields), and `proposal.type` fallback in CCIP messages
- Add plain-text fallback in `sendMessage`: if Telegram rejects a message due to Markdown parse error, retry immediately without `parse_mode` so **alerts are never silently dropped**
- `collateralSymbol` was used raw inside link text `[Buy ${sym} in Auction](url)` — exploitable for **link injection** (attacker could redirect auction links to a malicious URL)

## Background

Two live attacks triggered these fixes:
1. A malicious position proposal with a non-standard ERC20 token caused `name()` to revert — crashing the ponder indexer (fixed separately in ponder repo)
2. A malicious minter proposal with Markdown special characters in `applyMessage` caused the Telegram bot to fail with `400 Bad Request: can't parse entities` across all subscribed groups — governance alert was silently lost

## Test plan
- [ ] Trigger a minter proposal alert locally and confirm message sends with escaped special chars
- [ ] Trigger a position proposal alert with a token whose name/symbol contains `*`, `_`, `[` — confirm message sends
- [ ] Simulate a Markdown parse failure — confirm plain-text fallback fires and message is delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)